### PR TITLE
Java 8 support from pitest-0.33.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=info.solidsoft.gradle.pitest
-version=0.32.1-SNAPSHOT
-pitVersion=0.32
+version=0.33.0-SNAPSHOT
+pitVersion=0.33-SNAPSHOT


### PR DESCRIPTION
pitest is currently in SNAPSHOT, so I've left gradle-pitest-plugin version as SNAPSHOT to match (until pitest 0.33.0 is released).
