### PR TITLE
Configure Plugin Publishing Plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,12 +12,32 @@ buildscript {
     repositories {
         mavenCentral()
         mavenLocal()
+        maven {
+            url 'https://plugins.gradle.org/m2/'
+        }
     }
     dependencies {
         classpath 'pl.allegro.tech.build:axion-release-plugin:1.4.1'
         classpath 'com.bmuschko:gradle-nexus-plugin:2.3'
         classpath 'io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.5.3'
         classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.0.1'
+        classpath 'com.gradle.publish:plugin-publish-plugin:0.9.7'
+    }
+}
+
+apply plugin: 'com.gradle.plugin-publish'
+
+pluginBundle {
+    website = 'http://gradle-pitest-plugin.solidsoft.info/'
+    vcsUrl = 'https://github.com/szpak/gradle-pitest-plugin'
+
+    plugins {
+        plugin {
+            id = 'info.solidsoft.pitest'
+            displayName = 'Gradle plugin for PIT mutation testing'
+            description = 'Just what it says on the tin.'
+            tags = ['test', 'pit', 'mutation-testing']
+        }
     }
 }
 


### PR DESCRIPTION
Here's the output when I [published the plugin with my own id](https://plugins.gradle.org/plugin/com.thejohnfreeman.pitest) after already building it:

```
:compileJava UP-TO-DATE
:compileGroovy UP-TO-DATE
:processResources UP-TO-DATE
:classes UP-TO-DATE
:jar UP-TO-DATE
:groovydoc UP-TO-DATE
:javadocJar UP-TO-DATE
:sourcesJar UP-TO-DATE
:signArchives UP-TO-DATE
:publishPlugins
Ignoring unknown artifact type with extension "asc" and classifier ""
You can only upload normal jars, sources jars, javadoc jars and groovydoc jars
to the plugin portal at this time.
Ignoring unknown artifact type with extension "asc" and classifier "sources"
You can only upload normal jars, sources jars, javadoc jars and groovydoc jars
to the plugin portal at this time.
Ignoring unknown artifact type with extension "asc" and classifier "javadoc"
You can only upload normal jars, sources jars, javadoc jars and groovydoc jars
to the plugin portal at this time.
Publishing plugin com.thejohnfreeman.pitest version 1.1.12-SNAPSHOT
Publishing artifact build/libs/gradle-pitest-plugin-1.1.12-SNAPSHOT.jar
Publishing artifact build/libs/gradle-pitest-plugin-1.1.12-SNAPSHOT-sources.jar
Publishing artifact build/libs/gradle-pitest-plugin-1.1.12-SNAPSHOT-javadoc.jar
Publishing artifact build/publish-generated-resources/pom.xml
Activating plugin com.thejohnfreeman.pitest version 1.1.12-SNAPSHOT
```

This suggests to me that it reused the same built artifacts, just like you want.