### PR TITLE
Update obsolete link in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ configure(project(':itest')) {
 ```
 
 Minimal working multi-project build is available in
-[functional tests suite](https://github.com/szpak/gradle-pitest-plugin/tree/master/src/test/resources/testProjects/multiproject).
+[functional tests suite](https://github.com/szpak/gradle-pitest-plugin/tree/master/src/funcTest/resources/testProjects/multiproject).
 
 ## PIT test-plugins support
 


### PR DESCRIPTION
Hi `gradle-pitest-plugin` team,

I was wondering if you would accept my proposal to update obsolete link (`functional tests suite`) which currently refers to a page not found. Also, there is another mentioning of a nonexisting page,  but I'm not sure what to suggest in this case. Probably reference through a certain commit hash will work fine, though the snippet there might be out of date either.

The second link, I mentioned, is one at the end of section [PIT test-plugins support](https://github.com/szpak/gradle-pitest-plugin/blob/2ce7c85c94b73ac0caa1b51d1092c3ac0486cf48/README.md#pit-test-plugins-support)