### PR TITLE
React to java plugin being applied instead of applying it self

### DIFF
--- a/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/AbstractPitestFunctionalSpec.groovy
+++ b/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/AbstractPitestFunctionalSpec.groovy
@@ -12,6 +12,7 @@ abstract class AbstractPitestFunctionalSpec extends IntegrationSpec {
 
     protected static String getBasicGradlePitestConfig() {
         return """
+                apply plugin: 'java'
                 apply plugin: 'info.solidsoft.pitest'
                 group = 'gradle.pitest.test'
 

--- a/src/main/groovy/info/solidsoft/gradle/pitest/PitestPlugin.groovy
+++ b/src/main/groovy/info/solidsoft/gradle/pitest/PitestPlugin.groovy
@@ -25,6 +25,7 @@ import org.gradle.api.internal.file.UnionFileCollection
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 import org.gradle.api.plugins.JavaBasePlugin
+import org.gradle.api.plugins.JavaPlugin
 
 import static org.gradle.language.base.plugins.LifecycleBasePlugin.VERIFICATION_GROUP
 
@@ -51,10 +52,9 @@ class PitestPlugin implements Plugin<Project> {
 
     void apply(Project project) {
         this.project = project
-        applyRequiredJavaPlugin()
-        createConfigurations()
-        createExtension(project)
-        project.plugins.withType(JavaBasePlugin) {
+        project.plugins.withType(JavaPlugin).configureEach {
+            createConfigurations()
+            createExtension()
             PitestTask task = project.tasks.create(PITEST_TASK_NAME, PitestTask)
             task.with {
                 description = "Run PIT analysis for java classes"
@@ -62,12 +62,6 @@ class PitestPlugin implements Plugin<Project> {
             }
             configureTaskDefault(task)
         }
-    }
-
-    private void applyRequiredJavaPlugin() {
-        //The new Gradle plugin mechanism requires all mandatory plugins to be applied explicit
-        //See: https://github.com/szpak/gradle-pitest-plugin/issues/21
-        project.apply(plugin: 'java')
     }
 
     private void createConfigurations() {
@@ -78,7 +72,7 @@ class PitestPlugin implements Plugin<Project> {
     }
 
     //TODO: MZA: Maybe move it to the constructor of an extension class?
-    private void createExtension(Project project) {
+    private void createExtension() {
         extension = project.extensions.create("pitest", PitestPluginExtension)
         extension.reportDir = new File("${project.reporting.baseDir.path}/pitest")
         extension.pitestVersion = DEFAULT_PITEST_VERSION

--- a/src/test/groovy/info/solidsoft/gradle/pitest/PitestPluginTest.groovy
+++ b/src/test/groovy/info/solidsoft/gradle/pitest/PitestPluginTest.groovy
@@ -34,8 +34,7 @@ class PitestPluginTest extends Specification {
             assertThatTasksAreInGroup(project, [PitestPlugin.PITEST_TASK_NAME], PitestPlugin.PITEST_TASK_GROUP)
     }
 
-    @Issue("https://github.com/szpak/gradle-pitest-plugin/issues/21")
-    def "apply Java plugin itself of not already applied"() {
+    def "do nothing if Java plugin is not applied but react to it becoming applied"() {
         given:
             Project project = ProjectBuilder.builder().build()
         expect:
@@ -43,8 +42,11 @@ class PitestPluginTest extends Specification {
         when:
             project.apply(plugin: "info.solidsoft.pitest");
         then:
-            project.plugins.hasPlugin(PitestPlugin)
-            project.plugins.hasPlugin('java')
+            project.tasks.withType(PitestTask).isEmpty()
+        when:
+            project.apply(plugin: "java");
+        then:
+            !project.tasks.withType(PitestTask).isEmpty()
     }
 
     void assertThatTasksAreInGroup(Project project, List<String> taskNames, String group) {


### PR DESCRIPTION
Afair it is better practice to react to a plugin you need being applied
rather than force-applying it yourself.
So in case you want to adopt this practice, here are the required changes. :-)