### PR TITLE
Run after test task if both should be run

### DIFF
--- a/src/main/groovy/info/solidsoft/gradle/pitest/PitestPlugin.groovy
+++ b/src/main/groovy/info/solidsoft/gradle/pitest/PitestPlugin.groovy
@@ -31,6 +31,7 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.SourceSet
 import org.gradle.util.GradleVersion
 
+import static org.gradle.api.plugins.JavaPlugin.TEST_TASK_NAME
 import static org.gradle.language.base.plugins.LifecycleBasePlugin.VERIFICATION_GROUP
 
 /**
@@ -75,6 +76,7 @@ class PitestPlugin implements Plugin<Project> {
                 configureTaskDefault(t)
                 t.dependsOn(calculateTasksToDependOn())
                 addPitDependencies(createConfigurations())
+                t.shouldRunAfter(project.tasks.named(TEST_TASK_NAME))
             }
         }
     }


### PR DESCRIPTION
If both should be run, test should be run first.
If `--continue` is not used and some test fails,
it is better the `test` task finds this and fails, preventing `pitest` from being executed.
With the `test` task you often have better reporting of failed errors.