### PR TITLE
Java gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ dependencies {
 
 tasks.validateTaskProperties {
     enableStricterValidation = true
+    failOnWarning = true
 }
 
 task funcTest(type: Test) {

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'groovy'
+apply plugin: 'java-gradle-plugin'
 apply from: "$rootDir/gradle/cdeliveryboy-release.gradle"
 apply plugin: "com.github.ben-manes.versions"
 
@@ -35,7 +36,6 @@ sourceSets {
 }
 
 dependencies {
-    implementation gradleApi()
     implementation localGroovy()
 
     testImplementation('org.spockframework:spock-core:2.0-M2-groovy-2.5') {
@@ -55,6 +55,10 @@ dependencies {
     funcTestImplementation('com.netflix.nebula:nebula-test:7.8.5') {
         exclude group: 'org.codehaus.groovy', module: 'groovy-all'
     }
+}
+
+tasks.validateTaskProperties {
+    enableStricterValidation = true
 }
 
 task funcTest(type: Test) {

--- a/src/main/groovy/info/solidsoft/gradle/pitest/PitestTask.groovy
+++ b/src/main/groovy/info/solidsoft/gradle/pitest/PitestTask.groovy
@@ -35,6 +35,8 @@ import org.gradle.api.tasks.JavaExec
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.options.Option
 
 /**
@@ -141,6 +143,7 @@ class PitestTask extends JavaExec {
     final SetProperty<String> includedTestMethods
 
     @InputFiles
+    @PathSensitive(PathSensitivity.ABSOLUTE)
     Set<File> sourceDirs
 
     @Input
@@ -163,6 +166,7 @@ class PitestTask extends JavaExec {
     final RegularFileProperty additionalClasspathFile
 
     @InputFiles
+    @PathSensitive(PathSensitivity.ABSOLUTE)
     Set<File> mutableCodePaths
 
     @Input


### PR DESCRIPTION
Closes #106

`mutableCodePaths` and `srcDirs` likely shouldn't have sensitivity to the absolute path, but I've left if that way to match the current behaviour (absolute is used by default when no annotation is used).

I'd also suggest running `validateTaskProperties` task during CI but that can be added as you prefer.