### PR TITLE
Lint Groovy files with CodeNarc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,4 +95,5 @@ tasks.withType(Test).configureEach { testTask ->
 
 codenarc {
     toolVersion = "1.5"
+    reportFormat = "console"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'groovy'
+apply plugin: 'codenarc'
 apply from: "$rootDir/gradle/cdeliveryboy-release.gradle"
 apply plugin: "com.github.ben-manes.versions"
 
@@ -90,4 +91,8 @@ tasks.withType(Test).configureEach { testTask ->
             }
         }
     }
+}
+
+codenarc {
+    toolVersion = "1.5"
 }

--- a/config/codenarc/codenarc.xml
+++ b/config/codenarc/codenarc.xml
@@ -6,13 +6,18 @@
     <ruleset-ref path='rulesets/basic.xml' />
     <ruleset-ref path='rulesets/braces.xml' />
     <ruleset-ref path='rulesets/concurrency.xml' />
-    <ruleset-ref path='rulesets/convention.xml' />
-    <ruleset-ref path='rulesets/design.xml' />
+    <ruleset-ref path='rulesets/convention.xml'>
+        <exclude name="PublicMethodsBeforeNonPublicMethods" />
+    </ruleset-ref>
+    <ruleset-ref path='rulesets/design.xml'>
+        <exclude name="ReturnsNullInsteadOfEmptyCollection" />
+    </ruleset-ref>
     <ruleset-ref path='rulesets/dry.xml'>
         <exclude name='DuplicateStringLiteral' />
     </ruleset-ref>
     <ruleset-ref path='rulesets/exceptions.xml' />
     <ruleset-ref path='rulesets/formatting.xml'>
+        <exclude name="Indentation" />
         <exclude name="LineLength" />
     </ruleset-ref>
     <ruleset-ref path='rulesets/generic.xml' />
@@ -28,6 +33,8 @@
     <ruleset-ref path='rulesets/serialization.xml' />
     <ruleset-ref path='rulesets/unnecessary.xml'>
         <exclude name="UnnecessaryGetter" />
+        <exclude name="UnnecessaryGString" />
+        <exclude name="UnnecessaryReturnKeyword" />
     </ruleset-ref>
     <ruleset-ref path='rulesets/unused.xml' />
 </ruleset>

--- a/config/codenarc/codenarc.xml
+++ b/config/codenarc/codenarc.xml
@@ -1,0 +1,33 @@
+<ruleset xmlns="http://codenarc.org/ruleset/1.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://codenarc.org/ruleset/1.0 http://codenarc.org/ruleset-schema.xsd"
+         xsi:noNamespaceSchemaLocation="http://codenarc.org/ruleset-schema.xsd">
+
+    <ruleset-ref path='rulesets/basic.xml' />
+    <ruleset-ref path='rulesets/braces.xml' />
+    <ruleset-ref path='rulesets/concurrency.xml' />
+    <ruleset-ref path='rulesets/convention.xml' />
+    <ruleset-ref path='rulesets/design.xml' />
+    <ruleset-ref path='rulesets/dry.xml'>
+        <exclude name='DuplicateStringLiteral' />
+    </ruleset-ref>
+    <ruleset-ref path='rulesets/exceptions.xml' />
+    <ruleset-ref path='rulesets/formatting.xml'>
+        <exclude name="LineLength" />
+    </ruleset-ref>
+    <ruleset-ref path='rulesets/generic.xml' />
+    <ruleset-ref path='rulesets/groovyism.xml' />
+    <ruleset-ref path='rulesets/imports.xml' />
+    <ruleset-ref path='rulesets/junit.xml'>
+        <exclude name="JUnitPublicNonTestMethod" />
+    </ruleset-ref>
+    <ruleset-ref path='rulesets/logging.xml' />
+    <ruleset-ref path='rulesets/naming.xml'>
+        <exclude name="MethodName" />
+    </ruleset-ref>
+    <ruleset-ref path='rulesets/serialization.xml' />
+    <ruleset-ref path='rulesets/unnecessary.xml'>
+        <exclude name="UnnecessaryGetter" />
+    </ruleset-ref>
+    <ruleset-ref path='rulesets/unused.xml' />
+</ruleset>

--- a/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/AbstractPitestFunctionalSpec.groovy
+++ b/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/AbstractPitestFunctionalSpec.groovy
@@ -13,7 +13,7 @@ class AbstractPitestFunctionalSpec extends IntegrationSpec {
     }
 
     protected static String getBasicGradlePitestConfig() {
-        """
+        return """
                 apply plugin: 'java'
                 apply plugin: 'info.solidsoft.pitest'
                 group = 'gradle.pitest.test'
@@ -73,7 +73,7 @@ class AbstractPitestFunctionalSpec extends IntegrationSpec {
 
     //TODO: Switch to Gradle mechanism once upgraded to 6.x
     protected boolean isJava13Compatible() {
-        System.getProperty('java.version').startsWith('13') || System.getProperty('java.version').startsWith('14')
+        return System.getProperty("java.version").startsWith("13") || System.getProperty("java.version").startsWith("14")
     }
 
 }

--- a/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/AbstractPitestFunctionalSpec.groovy
+++ b/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/AbstractPitestFunctionalSpec.groovy
@@ -1,9 +1,11 @@
 package info.solidsoft.gradle.pitest.functional
 
+import groovy.transform.CompileDynamic
 import nebula.test.IntegrationSpec
 import nebula.test.functional.ExecutionResult
 
-abstract class AbstractPitestFunctionalSpec extends IntegrationSpec {
+@CompileDynamic
+class AbstractPitestFunctionalSpec extends IntegrationSpec {
 
     void setup() {
         fork = true //to make stdout assertion work with Gradle 2.x - http://forums.gradle.org/gradle/topics/unable-to-catch-stdout-stderr-when-using-tooling-api-i-gradle-2-x#reply_15357743
@@ -11,7 +13,7 @@ abstract class AbstractPitestFunctionalSpec extends IntegrationSpec {
     }
 
     protected static String getBasicGradlePitestConfig() {
-        return """
+        """
                 apply plugin: 'java'
                 apply plugin: 'info.solidsoft.pitest'
                 group = 'gradle.pitest.test'
@@ -36,8 +38,8 @@ abstract class AbstractPitestFunctionalSpec extends IntegrationSpec {
     }
 
     protected void writeHelloPitClass(String packageDotted = 'gradle.pitest.test.hello', File baseDir = getProjectDir()) {
-        def path = 'src/main/java/' + packageDotted.replace('.', '/') + '/HelloPit.java'
-        def javaFile = createFile(path, baseDir)
+        String path = 'src/main/java/' + packageDotted.replace('.', '/') + '/HelloPit.java'
+        File javaFile = createFile(path, baseDir)
         javaFile << """package ${packageDotted};
 
             public class HelloPit {
@@ -50,8 +52,8 @@ abstract class AbstractPitestFunctionalSpec extends IntegrationSpec {
     }
 
     protected void writeHelloPitTest(String packageDotted = 'gradle.pitest.test.hello', File baseDir = getProjectDir()) {
-        def path = 'src/test/java/' + packageDotted.replace('.', '/') + '/HelloPitTest.java'
-        def javaFile = createFile(path, baseDir)
+        String path = 'src/test/java/' + packageDotted.replace('.', '/') + '/HelloPitTest.java'
+        File javaFile = createFile(path, baseDir)
         javaFile << """package ${packageDotted};
             import org.junit.Test;
             import static org.junit.Assert.assertEquals;
@@ -71,6 +73,7 @@ abstract class AbstractPitestFunctionalSpec extends IntegrationSpec {
 
     //TODO: Switch to Gradle mechanism once upgraded to 6.x
     protected boolean isJava13Compatible() {
-        return System.getProperty("java.version").startsWith("13") || System.getProperty("java.version").startsWith("14")
+        System.getProperty('java.version').startsWith('13') || System.getProperty('java.version').startsWith('14')
     }
+
 }

--- a/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/AcceptanceTestsInSeparateSubprojectFunctionalSpec.groovy
+++ b/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/AcceptanceTestsInSeparateSubprojectFunctionalSpec.groovy
@@ -1,16 +1,21 @@
 package info.solidsoft.gradle.pitest.functional
 
+import groovy.transform.CompileDynamic
 import nebula.test.functional.ExecutionResult
 
+@CompileDynamic
 class AcceptanceTestsInSeparateSubprojectFunctionalSpec extends AbstractPitestFunctionalSpec {
 
-    def "should mutate production code in another subproject"() {
+    void "should mutate production code in another subproject"() {
         given:
-            copyResources("testProjects/multiproject", "")
+        copyResources('testProjects/multiproject', '')
+
         when:
-            ExecutionResult result = runTasksSuccessfully('pitest')
+        ExecutionResult result = runTasksSuccessfully('pitest')
+
         then:
-            result.wasExecuted(':itest:pitest')
-            result.getStandardOutput().contains('Generated 4 mutations Killed 3 (75%)')
+        result.wasExecuted(':itest:pitest')
+        result.getStandardOutput().contains('Generated 4 mutations Killed 3 (75%)')
     }
+
 }

--- a/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/AcceptanceTestsInSeparateSubprojectFunctionalSpec.groovy
+++ b/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/AcceptanceTestsInSeparateSubprojectFunctionalSpec.groovy
@@ -8,14 +8,12 @@ class AcceptanceTestsInSeparateSubprojectFunctionalSpec extends AbstractPitestFu
 
     void "should mutate production code in another subproject"() {
         given:
-        copyResources('testProjects/multiproject', '')
-
+            copyResources("testProjects/multiproject", "")
         when:
-        ExecutionResult result = runTasksSuccessfully('pitest')
-
+            ExecutionResult result = runTasksSuccessfully('pitest')
         then:
-        result.wasExecuted(':itest:pitest')
-        result.getStandardOutput().contains('Generated 4 mutations Killed 3 (75%)')
+            result.wasExecuted(':itest:pitest')
+            result.getStandardOutput().contains('Generated 4 mutations Killed 3 (75%)')
     }
 
 }

--- a/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/Junit5FunctionalSpec.groovy
+++ b/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/Junit5FunctionalSpec.groovy
@@ -9,30 +9,25 @@ class Junit5FunctionalSpec extends AbstractPitestFunctionalSpec {
 
     void "should work with kotlin and junit5"() {
         given:
-        copyResources('testProjects/junit5kotlin', '')
-
+            copyResources("testProjects/junit5kotlin", "")
         when:
-        ExecutionResult result = runTasksSuccessfully('pitest')
-
+            ExecutionResult result = runTasksSuccessfully('pitest')
         then:
-        result.wasExecuted('pitest')
-        result.standardOutput.contains('Generated 2 mutations Killed 2 (100%)')
+            result.wasExecuted('pitest')
+            result.standardOutput.contains('Generated 2 mutations Killed 2 (100%)')
     }
 
-    @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/177')
+    @Issue("https://github.com/szpak/gradle-pitest-plugin/issues/177")
     void "should work with junit5 without explicitly adding dependency"() {
         given:
-        copyResources('testProjects/junit5simple', '')
-
+            copyResources("testProjects/junit5simple", "")
         when:
-        ExecutionResult result = runTasksSuccessfully('pitest')
-
+            ExecutionResult result = runTasksSuccessfully('pitest')
         then:
-        result.wasExecuted('pitest')
-
+            result.wasExecuted('pitest')
         and:
-        result.standardOutput.contains('--testPlugin=junit5')
-        result.standardOutput.contains('Generated 1 mutations Killed 1 (100%)')
+            result.standardOutput.contains('--testPlugin=junit5')
+            result.standardOutput.contains('Generated 1 mutations Killed 1 (100%)')
     }
 
 }

--- a/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/Junit5FunctionalSpec.groovy
+++ b/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/Junit5FunctionalSpec.groovy
@@ -1,30 +1,38 @@
 package info.solidsoft.gradle.pitest.functional
 
+import groovy.transform.CompileDynamic
 import nebula.test.functional.ExecutionResult
 import spock.lang.Issue
 
+@CompileDynamic
 class Junit5FunctionalSpec extends AbstractPitestFunctionalSpec {
 
-    def "should work with kotlin and junit5"() {
+    void "should work with kotlin and junit5"() {
         given:
-            copyResources("testProjects/junit5kotlin", "")
+        copyResources('testProjects/junit5kotlin', '')
+
         when:
-            ExecutionResult result = runTasksSuccessfully('pitest')
+        ExecutionResult result = runTasksSuccessfully('pitest')
+
         then:
-            result.wasExecuted('pitest')
-            result.standardOutput.contains('Generated 2 mutations Killed 2 (100%)')
+        result.wasExecuted('pitest')
+        result.standardOutput.contains('Generated 2 mutations Killed 2 (100%)')
     }
 
-    @Issue("https://github.com/szpak/gradle-pitest-plugin/issues/177")
-    def "should work with junit5 without explicitly adding dependency"() {
+    @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/177')
+    void "should work with junit5 without explicitly adding dependency"() {
         given:
-            copyResources("testProjects/junit5simple", "")
+        copyResources('testProjects/junit5simple', '')
+
         when:
-            ExecutionResult result = runTasksSuccessfully('pitest')
+        ExecutionResult result = runTasksSuccessfully('pitest')
+
         then:
-            result.wasExecuted('pitest')
+        result.wasExecuted('pitest')
+
         and:
-            result.standardOutput.contains('--testPlugin=junit5')
-            result.standardOutput.contains('Generated 1 mutations Killed 1 (100%)')
+        result.standardOutput.contains('--testPlugin=junit5')
+        result.standardOutput.contains('Generated 1 mutations Killed 1 (100%)')
     }
+
 }

--- a/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/OverridePluginFunctionalSpec.groovy
+++ b/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/OverridePluginFunctionalSpec.groovy
@@ -1,10 +1,12 @@
 package info.solidsoft.gradle.pitest.functional
 
+import groovy.transform.CompileDynamic
 import nebula.test.functional.ExecutionResult
 import org.gradle.api.GradleException
 import spock.lang.Issue
 import spock.lang.PendingFeature
 
+@CompileDynamic
 class OverridePluginFunctionalSpec extends AbstractPitestFunctionalSpec {
 
     //Note: gradle-override-plugin has important limitations in support for collections
@@ -12,69 +14,79 @@ class OverridePluginFunctionalSpec extends AbstractPitestFunctionalSpec {
     //Update 201909. Gradle 4.6 introduced built-in support for overriding (with its on limitations, but also with support for lists):
     //    https://docs.gradle.org/6.2.1/userguide/custom_tasks.html#sec:declaring_and_using_command_line_options
     @PendingFeature(exceptions = GradleException, reason = "gradle-override-plugin nor @Option don't work with DirectoryProperty")
-    def "should allow to override String configuration parameter from command line"() {
+    void "should allow to override String configuration parameter from command line"() {
         given:
-            buildFile << """
-                apply plugin: 'java'
-                apply plugin: 'info.solidsoft.pitest'
-                apply plugin: 'nebula-override'
-                group = 'gradle.pitest.test'
+        buildFile << """
+            apply plugin: 'java'
+            apply plugin: 'info.solidsoft.pitest'
+            apply plugin: 'nebula-override'
+            group = 'gradle.pitest.test'
 
-                buildscript {
-                    repositories { mavenCentral() }
-                    dependencies { classpath 'com.netflix.nebula:gradle-override-plugin:1.12.+' }
-                }
+            buildscript {
                 repositories { mavenCentral() }
-                dependencies { testImplementation 'junit:junit:4.11' }
-            """.stripIndent()
+                dependencies { classpath 'com.netflix.nebula:gradle-override-plugin:1.12.+' }
+            }
+            repositories { mavenCentral() }
+            dependencies { testImplementation 'junit:junit:4.11' }
+        """.stripIndent()
+
         and:
-            writeHelloWorld('gradle.pitest.test.hello')
+        writeHelloWorld('gradle.pitest.test.hello')
+
         when:
-            ExecutionResult result = runTasksSuccessfully('pitest', '-Doverride.pitest.reportDir=build/treports')
+        ExecutionResult result = runTasksSuccessfully('pitest', '-Doverride.pitest.reportDir=build/treports')
+
         then:
-            result.standardOutput.contains('Generated 1 mutations Killed 0 (0%)')
-            fileExists('build/treports')
+        result.standardOutput.contains('Generated 1 mutations Killed 0 (0%)')
+        fileExists('build/treports')
     }
 
-    @Issue("https://github.com/szpak/gradle-pitest-plugin/issues/139")
-    @PendingFeature(exceptions = GradleException, reason = "Not implemented yet due to Gradle limitations described in linked issue")
-    def "should allow to define features from command line and override those from configuration"() {
+    @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/139')
+    @PendingFeature(exceptions = GradleException, reason = 'Not implemented yet due to Gradle limitations described in linked issue')
+    void "should allow to define features from command line and override those from configuration"() {
         given:
-            buildFile << """
-                ${getBasicGradlePitestConfig()}
+        buildFile << """
+            ${getBasicGradlePitestConfig()}
 
-                pitest {
-                    failWhenNoMutations = false
-                    timestampedReports = true
-                }
-            """.stripIndent()
+            pitest {
+                failWhenNoMutations = false
+                timestampedReports = true
+            }
+        """.stripIndent()
+
         when:
-            ExecutionResult result = runTasksSuccessfully('pitest', '--timestampedReports=false',
-                '--features=+EXPORT', '--features=-FINFINC')
+        ExecutionResult result = runTasksSuccessfully('pitest', '--timestampedReports=false',
+            '--features=+EXPORT', '--features=-FINFINC')
+
         then:
-            result.standardOutput.contains("--timestampedReports=false")
+        result.standardOutput.contains('--timestampedReports=false')
+
         and:
-            result.standardOutput.contains("--features=+EXPORT,-FINFINC")
+        result.standardOutput.contains('--features=+EXPORT,-FINFINC')
     }
 
-    @Issue("https://github.com/szpak/gradle-pitest-plugin/issues/143")
-    def "should allow to add features from command line to those from configuration and override selected tests"() {
+    @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/143')
+    void "should allow to add features from command line to those from configuration and override selected tests"() {
         given:
-            final String OVERRIDDEN_TARGET_TESTS = "com.foo.*"
-            buildFile << """
-                ${getBasicGradlePitestConfig()}
+        final String OVERRIDDEN_TARGET_TESTS = 'com.foo.*'
+        buildFile << """
+            ${getBasicGradlePitestConfig()}
 
-                pitest {
-                    failWhenNoMutations = false
-                    features = ['-FINFINC']
-                    targetTests = ['com.example.tests.*']
-                }
-            """.stripIndent()
+            pitest {
+                failWhenNoMutations = false
+                features = ['-FINFINC']
+                targetTests = ['com.example.tests.*']
+            }
+        """.stripIndent()
+
         when:
-            ExecutionResult result = runTasksSuccessfully('pitest', '--additionalFeatures=+EXPORT', "--targetTests=$OVERRIDDEN_TARGET_TESTS")
+        ExecutionResult result = runTasksSuccessfully('pitest', '--additionalFeatures=+EXPORT', "--targetTests=$OVERRIDDEN_TARGET_TESTS")
+
         then:
-            result.standardOutput.contains("--features=-FINFINC,+EXPORT")
+        result.standardOutput.contains('--features=-FINFINC,+EXPORT')
+
         and:
-            result.standardOutput.contains("--targetTests=${OVERRIDDEN_TARGET_TESTS}")
+        result.standardOutput.contains("--targetTests=${OVERRIDDEN_TARGET_TESTS}")
     }
+
 }

--- a/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/OverridePluginFunctionalSpec.groovy
+++ b/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/OverridePluginFunctionalSpec.groovy
@@ -16,77 +16,68 @@ class OverridePluginFunctionalSpec extends AbstractPitestFunctionalSpec {
     @PendingFeature(exceptions = GradleException, reason = "gradle-override-plugin nor @Option don't work with DirectoryProperty")
     void "should allow to override String configuration parameter from command line"() {
         given:
-        buildFile << """
-            apply plugin: 'java'
-            apply plugin: 'info.solidsoft.pitest'
-            apply plugin: 'nebula-override'
-            group = 'gradle.pitest.test'
+            buildFile << """
+                apply plugin: 'java'
+                apply plugin: 'info.solidsoft.pitest'
+                apply plugin: 'nebula-override'
+                group = 'gradle.pitest.test'
 
-            buildscript {
+                buildscript {
+                    repositories { mavenCentral() }
+                    dependencies { classpath 'com.netflix.nebula:gradle-override-plugin:1.12.+' }
+                }
                 repositories { mavenCentral() }
-                dependencies { classpath 'com.netflix.nebula:gradle-override-plugin:1.12.+' }
-            }
-            repositories { mavenCentral() }
-            dependencies { testImplementation 'junit:junit:4.11' }
-        """.stripIndent()
-
+                dependencies { testImplementation 'junit:junit:4.11' }
+            """.stripIndent()
         and:
-        writeHelloWorld('gradle.pitest.test.hello')
-
+            writeHelloWorld('gradle.pitest.test.hello')
         when:
-        ExecutionResult result = runTasksSuccessfully('pitest', '-Doverride.pitest.reportDir=build/treports')
-
+            ExecutionResult result = runTasksSuccessfully('pitest', '-Doverride.pitest.reportDir=build/treports')
         then:
-        result.standardOutput.contains('Generated 1 mutations Killed 0 (0%)')
-        fileExists('build/treports')
+            result.standardOutput.contains('Generated 1 mutations Killed 0 (0%)')
+            fileExists('build/treports')
     }
 
-    @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/139')
-    @PendingFeature(exceptions = GradleException, reason = 'Not implemented yet due to Gradle limitations described in linked issue')
+    @Issue("https://github.com/szpak/gradle-pitest-plugin/issues/139")
+    @PendingFeature(exceptions = GradleException, reason = "Not implemented yet due to Gradle limitations described in linked issue")
     void "should allow to define features from command line and override those from configuration"() {
         given:
-        buildFile << """
-            ${getBasicGradlePitestConfig()}
+            buildFile << """
+                ${getBasicGradlePitestConfig()}
 
-            pitest {
-                failWhenNoMutations = false
-                timestampedReports = true
-            }
-        """.stripIndent()
-
+                pitest {
+                    failWhenNoMutations = false
+                    timestampedReports = true
+                }
+            """.stripIndent()
         when:
-        ExecutionResult result = runTasksSuccessfully('pitest', '--timestampedReports=false',
-            '--features=+EXPORT', '--features=-FINFINC')
-
+            ExecutionResult result = runTasksSuccessfully('pitest', '--timestampedReports=false',
+                '--features=+EXPORT', '--features=-FINFINC')
         then:
-        result.standardOutput.contains('--timestampedReports=false')
-
+            result.standardOutput.contains("--timestampedReports=false")
         and:
-        result.standardOutput.contains('--features=+EXPORT,-FINFINC')
+            result.standardOutput.contains("--features=+EXPORT,-FINFINC")
     }
 
-    @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/143')
+    @Issue("https://github.com/szpak/gradle-pitest-plugin/issues/143")
     void "should allow to add features from command line to those from configuration and override selected tests"() {
         given:
-        final String OVERRIDDEN_TARGET_TESTS = 'com.foo.*'
-        buildFile << """
-            ${getBasicGradlePitestConfig()}
+            final String OVERRIDDEN_TARGET_TESTS = "com.foo.*"
+            buildFile << """
+                ${getBasicGradlePitestConfig()}
 
-            pitest {
-                failWhenNoMutations = false
-                features = ['-FINFINC']
-                targetTests = ['com.example.tests.*']
-            }
-        """.stripIndent()
-
+                pitest {
+                    failWhenNoMutations = false
+                    features = ['-FINFINC']
+                    targetTests = ['com.example.tests.*']
+                }
+            """.stripIndent()
         when:
-        ExecutionResult result = runTasksSuccessfully('pitest', '--additionalFeatures=+EXPORT', "--targetTests=$OVERRIDDEN_TARGET_TESTS")
-
+            ExecutionResult result = runTasksSuccessfully('pitest', '--additionalFeatures=+EXPORT', "--targetTests=$OVERRIDDEN_TARGET_TESTS")
         then:
-        result.standardOutput.contains('--features=-FINFINC,+EXPORT')
-
+            result.standardOutput.contains("--features=-FINFINC,+EXPORT")
         and:
-        result.standardOutput.contains("--targetTests=${OVERRIDDEN_TARGET_TESTS}")
+            result.standardOutput.contains("--targetTests=${OVERRIDDEN_TARGET_TESTS}")
     }
 
 }

--- a/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/PitestPluginGeneralFunctionalSpec.groovy
+++ b/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/PitestPluginGeneralFunctionalSpec.groovy
@@ -1,68 +1,81 @@
 package info.solidsoft.gradle.pitest.functional
 
+import groovy.transform.CompileDynamic
 import nebula.test.functional.ExecutionResult
 
+@CompileDynamic
 class PitestPluginGeneralFunctionalSpec extends AbstractPitestFunctionalSpec {
 
-    def "enable PIT plugin when on classpath and pass plugin configuration to PIT"() {
+    void "enable PIT plugin when on classpath and pass plugin configuration to PIT"() {
         given:
-            buildFile << getBasicGradlePitestConfig()
-            buildFile << """
-                buildscript {
-                    repositories {
-                        maven { url "https://dl.bintray.com/szpak/pitest-plugins/" }
-                    }
-                    configurations.maybeCreate("pitest")
-                    dependencies {
-                        pitest 'org.pitest.plugins:pitest-plugin-configuration-reporter-plugin:0.0.2'
-                    }
+        buildFile << getBasicGradlePitestConfig()
+        buildFile << """
+            buildscript {
+                repositories {
+                    maven { url "https://dl.bintray.com/szpak/pitest-plugins/" }
                 }
-                pitest {
-                    excludedClasses = []
-                    verbose = true
-                    pluginConfiguration = ['pitest-plugin-configuration-reporter-plugin.key1': 'value1',
-                                           'pitest-plugin-configuration-reporter-plugin.key2': 'value2']
-                    features = ["-FANN", "+FINFIT(a[1] a[2])"]
-                    outputFormats = ['pluginConfigurationReporter']
+                configurations.maybeCreate("pitest")
+                dependencies {
+                    pitest 'org.pitest.plugins:pitest-plugin-configuration-reporter-plugin:0.0.2'
                 }
-            """.stripIndent()
+            }
+            pitest {
+                excludedClasses = []
+                verbose = true
+                pluginConfiguration = ['pitest-plugin-configuration-reporter-plugin.key1': 'value1',
+                                       'pitest-plugin-configuration-reporter-plugin.key2': 'value2']
+                features = ["-FANN", "+FINFIT(a[1] a[2])"]
+                outputFormats = ['pluginConfigurationReporter']
+            }
+        """.stripIndent()
+
         and:
-            writeHelloPitClass()
-            writeHelloPitTest()
+        writeHelloPitClass()
+        writeHelloPitTest()
+
         when:
-            ExecutionResult result = runTasksSuccessfully('pitest')
+        ExecutionResult result = runTasksSuccessfully('pitest')
+
         then:
-            result.wasExecuted(':pitest')
+        result.wasExecuted(':pitest')
+
         and: 'plugin enabled'
-            assertStdOutOrStdErrContainsGivenText(result, 'with the following plugin configuration')
+        assertStdOutOrStdErrContainsGivenText(result, 'with the following plugin configuration')
+
         and: 'plugin parameters passed'
-            result.getStandardOutput().contains('pitest-plugin-configuration-reporter-plugin.key1=value1')
-            result.getStandardOutput().contains('pitest-plugin-configuration-reporter-plugin.key2=value2')
+        result.getStandardOutput().contains('pitest-plugin-configuration-reporter-plugin.key1=value1')
+        result.getStandardOutput().contains('pitest-plugin-configuration-reporter-plugin.key2=value2')
+
         and: 'built-in features passed'
-            result.getStandardOutput().contains("-FANN")
-            result.getStandardOutput().contains("+FINFIT")
+        result.getStandardOutput().contains('-FANN')
+        result.getStandardOutput().contains('+FINFIT')
+
         and: 'verbose output enabled'
-            assertStdOutOrStdErrContainsGivenText(result, "PIT >> FINE")
-            //TODO: Add plugin features once available - https://github.com/hcoles/pitest-plugins/issues/2
+        assertStdOutOrStdErrContainsGivenText(result, 'PIT >> FINE')
+        //TODO: Add plugin features once available - https://github.com/hcoles/pitest-plugins/issues/2
     }
 
-    def "use file to pass additional classpath to PIT if enabled"() {   //Needed? Already tested with ProjectBuilder in PitestTaskConfigurationSpec
+    void "use file to pass additional classpath to PIT if enabled"() {   //Needed? Already tested with ProjectBuilder in PitestTaskConfigurationSpec
         given:
-            buildFile << getBasicGradlePitestConfig()
-            buildFile << """
-                pitest {
-                    useClasspathFile = true
-                }
-            """.stripIndent()
+        buildFile << getBasicGradlePitestConfig()
+        buildFile << '''
+            pitest {
+                useClasspathFile = true
+            }
+        '''.stripIndent()
+
         and:
-            writeHelloPitClass()
-            writeHelloPitTest()
+        writeHelloPitClass()
+        writeHelloPitTest()
+
         when:
-            ExecutionResult result = runTasksSuccessfully('pitest')
+        ExecutionResult result = runTasksSuccessfully('pitest')
+
         then:
-            result.wasExecuted(':pitest')
-            result.getStandardOutput().contains('--classPathFile=')
-            //TODO: Verify file name with regex
-            !result.getStandardOutput().find("--classPath=")
+        result.wasExecuted(':pitest')
+        result.getStandardOutput().contains('--classPathFile=')
+        //TODO: Verify file name with regex
+        !result.getStandardOutput().find('--classPath=')
     }
+
 }

--- a/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/PitestPluginGeneralFunctionalSpec.groovy
+++ b/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/PitestPluginGeneralFunctionalSpec.groovy
@@ -8,74 +8,64 @@ class PitestPluginGeneralFunctionalSpec extends AbstractPitestFunctionalSpec {
 
     void "enable PIT plugin when on classpath and pass plugin configuration to PIT"() {
         given:
-        buildFile << getBasicGradlePitestConfig()
-        buildFile << """
-            buildscript {
-                repositories {
-                    maven { url "https://dl.bintray.com/szpak/pitest-plugins/" }
+            buildFile << getBasicGradlePitestConfig()
+            buildFile << """
+                buildscript {
+                    repositories {
+                        maven { url "https://dl.bintray.com/szpak/pitest-plugins/" }
+                    }
+                    configurations.maybeCreate("pitest")
+                    dependencies {
+                        pitest 'org.pitest.plugins:pitest-plugin-configuration-reporter-plugin:0.0.2'
+                    }
                 }
-                configurations.maybeCreate("pitest")
-                dependencies {
-                    pitest 'org.pitest.plugins:pitest-plugin-configuration-reporter-plugin:0.0.2'
+                pitest {
+                    excludedClasses = []
+                    verbose = true
+                    pluginConfiguration = ['pitest-plugin-configuration-reporter-plugin.key1': 'value1',
+                                           'pitest-plugin-configuration-reporter-plugin.key2': 'value2']
+                    features = ["-FANN", "+FINFIT(a[1] a[2])"]
+                    outputFormats = ['pluginConfigurationReporter']
                 }
-            }
-            pitest {
-                excludedClasses = []
-                verbose = true
-                pluginConfiguration = ['pitest-plugin-configuration-reporter-plugin.key1': 'value1',
-                                       'pitest-plugin-configuration-reporter-plugin.key2': 'value2']
-                features = ["-FANN", "+FINFIT(a[1] a[2])"]
-                outputFormats = ['pluginConfigurationReporter']
-            }
-        """.stripIndent()
-
+            """.stripIndent()
         and:
-        writeHelloPitClass()
-        writeHelloPitTest()
-
+            writeHelloPitClass()
+            writeHelloPitTest()
         when:
-        ExecutionResult result = runTasksSuccessfully('pitest')
-
+            ExecutionResult result = runTasksSuccessfully('pitest')
         then:
-        result.wasExecuted(':pitest')
-
+            result.wasExecuted(':pitest')
         and: 'plugin enabled'
-        assertStdOutOrStdErrContainsGivenText(result, 'with the following plugin configuration')
-
+            assertStdOutOrStdErrContainsGivenText(result, 'with the following plugin configuration')
         and: 'plugin parameters passed'
-        result.getStandardOutput().contains('pitest-plugin-configuration-reporter-plugin.key1=value1')
-        result.getStandardOutput().contains('pitest-plugin-configuration-reporter-plugin.key2=value2')
-
+            result.getStandardOutput().contains('pitest-plugin-configuration-reporter-plugin.key1=value1')
+            result.getStandardOutput().contains('pitest-plugin-configuration-reporter-plugin.key2=value2')
         and: 'built-in features passed'
-        result.getStandardOutput().contains('-FANN')
-        result.getStandardOutput().contains('+FINFIT')
-
+            result.getStandardOutput().contains("-FANN")
+            result.getStandardOutput().contains("+FINFIT")
         and: 'verbose output enabled'
-        assertStdOutOrStdErrContainsGivenText(result, 'PIT >> FINE')
-        //TODO: Add plugin features once available - https://github.com/hcoles/pitest-plugins/issues/2
+            assertStdOutOrStdErrContainsGivenText(result, "PIT >> FINE")
+            //TODO: Add plugin features once available - https://github.com/hcoles/pitest-plugins/issues/2
     }
 
     void "use file to pass additional classpath to PIT if enabled"() {   //Needed? Already tested with ProjectBuilder in PitestTaskConfigurationSpec
         given:
-        buildFile << getBasicGradlePitestConfig()
-        buildFile << '''
-            pitest {
-                useClasspathFile = true
-            }
-        '''.stripIndent()
-
+            buildFile << getBasicGradlePitestConfig()
+            buildFile << """
+                pitest {
+                    useClasspathFile = true
+                }
+            """.stripIndent()
         and:
-        writeHelloPitClass()
-        writeHelloPitTest()
-
+            writeHelloPitClass()
+            writeHelloPitTest()
         when:
-        ExecutionResult result = runTasksSuccessfully('pitest')
-
+            ExecutionResult result = runTasksSuccessfully('pitest')
         then:
-        result.wasExecuted(':pitest')
-        result.getStandardOutput().contains('--classPathFile=')
-        //TODO: Verify file name with regex
-        !result.getStandardOutput().find('--classPath=')
+            result.wasExecuted(':pitest')
+            result.getStandardOutput().contains('--classPathFile=')
+            //TODO: Verify file name with regex
+            !result.getStandardOutput().find("--classPath=")
     }
 
 }

--- a/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/PitestPluginGradleVersionFunctionalSpec.groovy
+++ b/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/PitestPluginGradleVersionFunctionalSpec.groovy
@@ -1,7 +1,10 @@
 package info.solidsoft.gradle.pitest.functional
 
+import static info.solidsoft.gradle.pitest.PitestTaskConfigurationSpec.PIT_PARAMETERS_NAMES_NOT_SET_BY_DEFAULT
+
 import com.google.common.base.Predicate
 import com.google.common.base.Predicates
+import groovy.transform.CompileDynamic
 import groovy.util.logging.Slf4j
 import info.solidsoft.gradle.pitest.PitestPlugin
 import nebula.test.functional.ExecutionResult
@@ -15,8 +18,6 @@ import spock.util.Exceptions
 
 import java.util.regex.Pattern
 
-import static info.solidsoft.gradle.pitest.PitestTaskConfigurationSpec.PIT_PARAMETERS_NAMES_NOT_SET_BY_DEFAULT
-
 /**
  * TODO: Possible extensions:
  *  - Move functional tests to a separate sourceSet and not run them in every build - DONE
@@ -25,84 +26,96 @@ import static info.solidsoft.gradle.pitest.PitestTaskConfigurationSpec.PIT_PARAM
  *  - Add testing against latest nightly Gradle version?
  */
 @Slf4j
-@SuppressWarnings("GrMethodMayBeStatic")
+@SuppressWarnings('GrMethodMayBeStatic')
+@CompileDynamic
 class PitestPluginGradleVersionFunctionalSpec extends AbstractPitestFunctionalSpec {
 
     //4.8, but plugin requires 5.6
     private static final GradleVersion MINIMAL_SUPPORTED_JAVA12_COMPATIBLE_GRADLE_VERSION = PitestPlugin.MINIMAL_SUPPORTED_GRADLE_VERSION
     //6.0+ - https://github.com/gradle/gradle/issues/8681#issuecomment-532507276
-    private static final GradleVersion MINIMAL_SUPPORTED_JAVA13_COMPATIBLE_GRADLE_VERSION = GradleVersion.version("6.0.1")
+    private static final GradleVersion MINIMAL_SUPPORTED_JAVA13_COMPATIBLE_GRADLE_VERSION = GradleVersion.version('6.0.1')
 
     void setup() {
         daemonMaxIdleTimeInSecondsInMemorySafeMode = 1  //trying to mitigate "Gradle killed" issues with Travis
     }
 
-    def "should run mutation analysis with Gradle #requestedGradleVersion"() {
+    void "should run mutation analysis with Gradle #requestedGradleVersion"() {
         given:
-            gradleVersion = requestedGradleVersion
-            classpathFilter = Predicates.and(GradleRunner.CLASSPATH_DEFAULT, FILTER_SPOCK_JAR)
+        gradleVersion = requestedGradleVersion
+        classpathFilter = Predicates.and(GradleRunner.CLASSPATH_DEFAULT, FILTER_SPOCK_JAR)
+
         when:
-            copyResources("testProjects/simple1", "")
+        copyResources('testProjects/simple1', '')
+
         then:
-            fileExists('build.gradle')
+        fileExists('build.gradle')
+
         when:
-            ExecutionResult result = runTasksSuccessfully('pitest', '--warning-mode', 'all')
+        ExecutionResult result = runTasksSuccessfully('pitest', '--warning-mode', 'all')
+
         then:
-            result.wasExecuted(':pitest')
-            result.standardOutput.contains('Generated 1 mutations Killed 1 (100%)')
+        result.wasExecuted(':pitest')
+        result.standardOutput.contains('Generated 1 mutations Killed 1 (100%)')
+
         and:    //issue with Gradle <5.0 where Integer/Boolean property had 0/false provided by default
-            //TODO: verifyAll would be great, but it's broken with explicit "assert" - https://github.com/spockframework/spock/issues/855#issuecomment-528411874
-            PIT_PARAMETERS_NAMES_NOT_SET_BY_DEFAULT.each {
-                assert !result.standardOutput.contains("${it}=")
-            }
+        //TODO: verifyAll would be great, but it's broken with explicit "assert" - https://github.com/spockframework/spock/issues/855#issuecomment-528411874
+        PIT_PARAMETERS_NAMES_NOT_SET_BY_DEFAULT.each { parameterName ->
+            assert !result.standardOutput.contains("${parameterName}=")
+        }
+
         where:
-            requestedGradleVersion << applyJavaCompatibilityAdjustment(resolveRequestedGradleVersions()).unique()
+        requestedGradleVersion << applyJavaCompatibilityAdjustment(resolveRequestedGradleVersions()).unique()
     }
 
-    @IgnoreIf({new PreconditionContext().javaVersion >= 13 })   //There is no unsupported version of Gradle which can be used with Java 13
-    def "should fail with meaningful error message with too old Gradle version"() {
+    @IgnoreIf({ new PreconditionContext().javaVersion >= 13 })   //There is no unsupported version of Gradle which can be used with Java 13
+    void "should fail with meaningful error message with too old Gradle version"() {
         given:
-            gradleVersion = "5.5.1"
+        gradleVersion = '5.5.1'
+
         and:
-            assert PitestPlugin.MINIMAL_SUPPORTED_GRADLE_VERSION.compareTo(GradleVersion.version(gradleVersion)) > 0
+        assert PitestPlugin.MINIMAL_SUPPORTED_GRADLE_VERSION > GradleVersion.version(gradleVersion)
+
         when:
-            copyResources("testProjects/simple1", "")
+        copyResources('testProjects/simple1', '')
+
         then:
-            fileExists('build.gradle')
+        fileExists('build.gradle')
+
         when:
-            ExecutionResult result = runTasksWithFailure('tasks')
+        ExecutionResult result = runTasksWithFailure('tasks')
+
         then:
-            verifyAll {
-                def root = Exceptions.getRootCause(result.failure)
-                root.class.name == GradleException.name //name to mitigate differences on classloader
-                root.message.contains("'info.solidsoft.pitest' requires")
-                result.standardOutput.contains("WARNING. The 'info.solidsoft.pitest' plugin requires")
-            }
+        verifyAll {
+            Throwable root = Exceptions.getRootCause(result.failure)
+            root.class.name == GradleException.name //name to mitigate differences on classloader
+            root.message.contains("'info.solidsoft.pitest' requires")
+            result.standardOutput.contains("WARNING. The 'info.solidsoft.pitest' plugin requires")
+        }
     }
 
     //To prevent failure when Spock for Groovy 2.4 is run with Groovy 2.3 delivered with Gradle <2.8
     //Spock is not needed in this artificial project - just the test classpath leaks to Gradle instance started by Nebula
-    private static final Pattern SPOCK_JAR_PATTERN = Pattern.compile(".*spock-core-1\\..*.jar")
+    private static final Pattern SPOCK_JAR_PATTERN = Pattern.compile('.*spock-core-1\\..*.jar')
     private static final Predicate<URL> FILTER_SPOCK_JAR = { URL url ->
-        return !url.toExternalForm().matches(SPOCK_JAR_PATTERN)
+        !url.toExternalForm().matches(SPOCK_JAR_PATTERN)
     } as Predicate<URL>
 
     //TODO: Extract regression tests control mechanism to a separate class (or even better trait) when needed in some other place
-    private static final String REGRESSION_TESTS_ENV_NAME = "PITEST_REGRESSION_TESTS"
-    private static final List<String> GRADLE5_VERSIONS = ["5.6.1", "5.6"]
-    private static final List<String> GRADLE6_VERSIONS = ["6.2.1", "6.1.1", MINIMAL_SUPPORTED_JAVA13_COMPATIBLE_GRADLE_VERSION.version]
+    private static final String REGRESSION_TESTS_ENV_NAME = 'PITEST_REGRESSION_TESTS'
+    private static final List<String> GRADLE5_VERSIONS = ['5.6.1', '5.6']
+    private static final List<String> GRADLE6_VERSIONS = ['6.2.1', '6.1.1', MINIMAL_SUPPORTED_JAVA13_COMPATIBLE_GRADLE_VERSION.version]
     private static final List<String> GRADLE_LATEST_VERSIONS = [GRADLE5_VERSIONS.first(), GRADLE6_VERSIONS.first()]
 
     private List<String> resolveRequestedGradleVersions() {
         String regressionTestsLevel = System.getenv(REGRESSION_TESTS_ENV_NAME)
         log.debug("$REGRESSION_TESTS_ENV_NAME set to '${regressionTestsLevel}'")
         switch (regressionTestsLevel) {
-            case "latestOnly":
+            case 'latestOnly':
             case null:
                 return GRADLE_LATEST_VERSIONS + GRADLE5_VERSIONS.last() //after 4.x support removal also with 5.1.1
-            case "quick":
+            case 'quick':
                 return GRADLE_LATEST_VERSIONS + GRADLE5_VERSIONS.last()
-            case "full":
+            case 'full':
                 return GRADLE5_VERSIONS + GRADLE6_VERSIONS
             default:
                 log.warn("Unsupported $REGRESSION_TESTS_ENV_NAME value '`$regressionTestsLevel`' (expected 'latestOnly', 'quick' or 'full'). " +
@@ -117,18 +130,19 @@ class PitestPluginGradleVersionFunctionalSpec extends AbstractPitestFunctionalSp
             //All supported versions should be Java 8 compatible
             return requestedGradleVersions
         }
-        GradleVersion minimalCompatibleGradleVersion = !isJava13Compatible() ? MINIMAL_SUPPORTED_JAVA12_COMPATIBLE_GRADLE_VERSION :
-            MINIMAL_SUPPORTED_JAVA13_COMPATIBLE_GRADLE_VERSION
-        return leaveJavaXCompatibleGradleVersionsOnly(requestedGradleVersions, minimalCompatibleGradleVersion)
+        GradleVersion minimalCompatibleGradleVersion = isJava13Compatible() ? MINIMAL_SUPPORTED_JAVA13_COMPATIBLE_GRADLE_VERSION :
+            MINIMAL_SUPPORTED_JAVA12_COMPATIBLE_GRADLE_VERSION
+        leaveJavaXCompatibleGradleVersionsOnly(requestedGradleVersions, minimalCompatibleGradleVersion)
     }
 
     private List<String> leaveJavaXCompatibleGradleVersionsOnly(List<String> requestedGradleVersions, GradleVersion minimalCompatibleJavaVersion) {
-        List<String> javaXCompatibleGradleVersions = requestedGradleVersions.findAll {
-            GradleVersion.version(it) >= minimalCompatibleJavaVersion
+        List<String> javaXCompatibleGradleVersions = requestedGradleVersions.findAll { version ->
+            GradleVersion.version(version) >= minimalCompatibleJavaVersion
         }
         if (javaXCompatibleGradleVersions.size() < 2) {
             javaXCompatibleGradleVersions.add(minimalCompatibleJavaVersion.version)
         }
-        return javaXCompatibleGradleVersions
+        javaXCompatibleGradleVersions
     }
+
 }

--- a/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/PitestPluginPitVersionFunctionalSpec.groovy
+++ b/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/PitestPluginPitVersionFunctionalSpec.groovy
@@ -1,41 +1,50 @@
 package info.solidsoft.gradle.pitest.functional
 
+import groovy.transform.CompileDynamic
 import info.solidsoft.gradle.pitest.PitestPlugin
 import nebula.test.functional.ExecutionResult
 import org.gradle.internal.jvm.Jvm
 
-@SuppressWarnings("GrMethodMayBeStatic")
+@SuppressWarnings('GrMethodMayBeStatic')
+@CompileDynamic
 class PitestPluginPitVersionFunctionalSpec extends AbstractPitestFunctionalSpec {
 
-    private static final String PIT_1_3_VERSION = "1.3.1"
-    private static final String MINIMAL_JAVA9_COMPATIBLE_PIT_VERSION = "1.2.3"  //https://github.com/hcoles/pitest/issues/380
-    private static final String MINIMAL_JAVA10_COMPATIBLE_PIT_VERSION = "1.4.0"
-    private static final String MINIMAL_JAVA11_COMPATIBLE_PIT_VERSION = "1.4.2" //in fact 1.4.1, but 1.4.2 is also Java 12 compatible
-    private static final String MINIMAL_JAVA13_COMPATIBLE_PIT_VERSION = "1.4.6" //not officially, but at least simple case works
+    private static final String PIT_1_3_VERSION = '1.3.1'
+    private static final String MINIMAL_JAVA9_COMPATIBLE_PIT_VERSION = '1.2.3'  //https://github.com/hcoles/pitest/issues/380
+    private static final String MINIMAL_JAVA10_COMPATIBLE_PIT_VERSION = '1.4.0'
+    private static final String MINIMAL_JAVA11_COMPATIBLE_PIT_VERSION = '1.4.2' //in fact 1.4.1, but 1.4.2 is also Java 12 compatible
+    private static final String MINIMAL_JAVA13_COMPATIBLE_PIT_VERSION = '1.4.6' //not officially, but at least simple case works
 
-    def "setup and run pitest task with PIT #pitVersion"() {
+    void "setup and run pitest task with PIT #pitVersion"() {
         given:
-            buildFile << getBasicGradlePitestConfig()
+        buildFile << getBasicGradlePitestConfig()
+
         and:
-            buildFile << """
-                pitest {
-                    pitestVersion = '$pitVersion'
-                }
-            """.stripIndent()
+        buildFile << """
+            pitest {
+                pitestVersion = '$pitVersion'
+            }
+        """.stripIndent()
+
         and:
-            writeHelloPitClass()
-            writeHelloPitTest()
+        writeHelloPitClass()
+        writeHelloPitTest()
+
         when:
-            ExecutionResult result = runTasksSuccessfully('pitest')
+        ExecutionResult result = runTasksSuccessfully('pitest')
+
         then:
-            result.wasExecuted(':pitest')
+        result.wasExecuted(':pitest')
+
         and:
-            result.standardOutput.contains("Using PIT: ${pitVersion}")
+        result.standardOutput.contains("Using PIT: ${pitVersion}")
+
         and:
-            result.standardOutput.contains('Generated 2 mutations Killed 1 (50%)')
-            result.standardOutput.contains('Ran 2 tests (1 tests per mutation)')
+        result.standardOutput.contains('Generated 2 mutations Killed 1 (50%)')
+        result.standardOutput.contains('Ran 2 tests (1 tests per mutation)')
+
         where:
-            pitVersion << getPitVersionsCompoatibleWithCurrentJavaVersion().unique() //be aware that unique() is available since Groovy 2.4.0
+        pitVersion << getPitVersionsCompoatibleWithCurrentJavaVersion().unique() //be aware that unique() is available since Groovy 2.4.0
     }
 
     private List<String> getPitVersionsCompoatibleWithCurrentJavaVersion() {
@@ -51,6 +60,7 @@ class PitestPluginPitVersionFunctionalSpec extends AbstractPitestFunctionalSpec 
         if (Jvm.current().javaVersion.isJava9Compatible()) {
             return [PitestPlugin.DEFAULT_PITEST_VERSION, MINIMAL_JAVA9_COMPATIBLE_PIT_VERSION, PIT_1_3_VERSION]
         }
-        return [PitestPlugin.DEFAULT_PITEST_VERSION, "1.1.5", "1.2.0", PIT_1_3_VERSION, "1.4.0"]
+        [PitestPlugin.DEFAULT_PITEST_VERSION, '1.1.5', '1.2.0', PIT_1_3_VERSION, '1.4.0']
     }
+
 }

--- a/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/PitestPluginPitVersionFunctionalSpec.groovy
+++ b/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/PitestPluginPitVersionFunctionalSpec.groovy
@@ -5,52 +5,47 @@ import info.solidsoft.gradle.pitest.PitestPlugin
 import nebula.test.functional.ExecutionResult
 import org.gradle.internal.jvm.Jvm
 
-@SuppressWarnings('GrMethodMayBeStatic')
+@SuppressWarnings("GrMethodMayBeStatic")
 @CompileDynamic
 class PitestPluginPitVersionFunctionalSpec extends AbstractPitestFunctionalSpec {
 
-    private static final String PIT_1_3_VERSION = '1.3.1'
-    private static final String MINIMAL_JAVA9_COMPATIBLE_PIT_VERSION = '1.2.3'  //https://github.com/hcoles/pitest/issues/380
-    private static final String MINIMAL_JAVA10_COMPATIBLE_PIT_VERSION = '1.4.0'
-    private static final String MINIMAL_JAVA11_COMPATIBLE_PIT_VERSION = '1.4.2' //in fact 1.4.1, but 1.4.2 is also Java 12 compatible
-    private static final String MINIMAL_JAVA13_COMPATIBLE_PIT_VERSION = '1.4.6' //not officially, but at least simple case works
+    private static final String PIT_1_3_VERSION = "1.3.1"
+    private static final String MINIMAL_JAVA9_COMPATIBLE_PIT_VERSION = "1.2.3"  //https://github.com/hcoles/pitest/issues/380
+    private static final String MINIMAL_JAVA10_COMPATIBLE_PIT_VERSION = "1.4.0"
+    private static final String MINIMAL_JAVA11_COMPATIBLE_PIT_VERSION = "1.4.2" //in fact 1.4.1, but 1.4.2 is also Java 12 compatible
+    private static final String MINIMAL_JAVA13_COMPATIBLE_PIT_VERSION = "1.4.6" //not officially, but at least simple case works
 
     void "setup and run pitest task with PIT #pitVersion"() {
         given:
-        buildFile << getBasicGradlePitestConfig()
-
+            buildFile << getBasicGradlePitestConfig()
         and:
-        buildFile << """
-            pitest {
-                pitestVersion = '$pitVersion'
-            }
-        """.stripIndent()
-
+            buildFile << """
+                pitest {
+                    pitestVersion = '$pitVersion'
+                }
+            """.stripIndent()
         and:
-        writeHelloPitClass()
-        writeHelloPitTest()
-
+            writeHelloPitClass()
+            writeHelloPitTest()
         when:
-        ExecutionResult result = runTasksSuccessfully('pitest')
-
+            ExecutionResult result = runTasksSuccessfully('pitest')
         then:
-        result.wasExecuted(':pitest')
-
+            result.wasExecuted(':pitest')
         and:
-        result.standardOutput.contains("Using PIT: ${pitVersion}")
-
+            result.standardOutput.contains("Using PIT: ${pitVersion}")
         and:
-        result.standardOutput.contains('Generated 2 mutations Killed 1 (50%)')
-        result.standardOutput.contains('Ran 2 tests (1 tests per mutation)')
-
+            result.standardOutput.contains('Generated 2 mutations Killed 1 (50%)')
+            result.standardOutput.contains('Ran 2 tests (1 tests per mutation)')
         where:
-        pitVersion << getPitVersionsCompoatibleWithCurrentJavaVersion().unique() //be aware that unique() is available since Groovy 2.4.0
+            pitVersion << getPitVersionsCompatibleWithCurrentJavaVersion().unique() //be aware that unique() is available since Groovy 2.4.0
     }
 
-    private List<String> getPitVersionsCompoatibleWithCurrentJavaVersion() {
+    @SuppressWarnings("IfStatementCouldBeTernary")
+    private List<String> getPitVersionsCompatibleWithCurrentJavaVersion() {
         if (isJava13Compatible()) {
             return [PitestPlugin.DEFAULT_PITEST_VERSION, MINIMAL_JAVA13_COMPATIBLE_PIT_VERSION]
         }
+
         if (Jvm.current().javaVersion.isJava11Compatible()) {
             return [PitestPlugin.DEFAULT_PITEST_VERSION, MINIMAL_JAVA11_COMPATIBLE_PIT_VERSION]
         }
@@ -60,7 +55,7 @@ class PitestPluginPitVersionFunctionalSpec extends AbstractPitestFunctionalSpec 
         if (Jvm.current().javaVersion.isJava9Compatible()) {
             return [PitestPlugin.DEFAULT_PITEST_VERSION, MINIMAL_JAVA9_COMPATIBLE_PIT_VERSION, PIT_1_3_VERSION]
         }
-        [PitestPlugin.DEFAULT_PITEST_VERSION, '1.1.5', '1.2.0', PIT_1_3_VERSION, '1.4.0']
+        return [PitestPlugin.DEFAULT_PITEST_VERSION, "1.1.5", "1.2.0", PIT_1_3_VERSION, "1.4.0"]
     }
 
 }

--- a/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/TargetClassesFunctionalSpec.groovy
+++ b/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/TargetClassesFunctionalSpec.groovy
@@ -8,19 +8,16 @@ class TargetClassesFunctionalSpec extends AbstractPitestFunctionalSpec {
 
     void "report error when no project group and no targetClasses parameter are defined"() {
         given:
-        buildFile << """
-            apply plugin: 'java'
-            apply plugin: 'info.solidsoft.pitest'
-        """.stripIndent()
-
+            buildFile << """
+                apply plugin: 'java'
+                apply plugin: 'info.solidsoft.pitest'
+            """.stripIndent()
         and:
-        writeHelloWorld('gradle.pitest.test.hello')
-
+            writeHelloWorld('gradle.pitest.test.hello')
         when:
-        ExecutionResult result = runTasksWithFailure('pitest')
-
+            ExecutionResult result = runTasksWithFailure('pitest')
         then:
-        assertStdOutOrStdErrContainsGivenText(result, "No value has been specified for property 'targetClasses'")
+            assertStdOutOrStdErrContainsGivenText(result, "No value has been specified for property 'targetClasses'")
     }
 
 }

--- a/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/TargetClassesFunctionalSpec.groovy
+++ b/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/TargetClassesFunctionalSpec.groovy
@@ -1,20 +1,26 @@
 package info.solidsoft.gradle.pitest.functional
 
+import groovy.transform.CompileDynamic
 import nebula.test.functional.ExecutionResult
 
+@CompileDynamic
 class TargetClassesFunctionalSpec extends AbstractPitestFunctionalSpec {
 
-    def "report error when no project group and no targetClasses parameter are defined"() {
+    void "report error when no project group and no targetClasses parameter are defined"() {
         given:
-            buildFile << """
-                apply plugin: 'java'
-                apply plugin: 'info.solidsoft.pitest'
-            """.stripIndent()
+        buildFile << """
+            apply plugin: 'java'
+            apply plugin: 'info.solidsoft.pitest'
+        """.stripIndent()
+
         and:
-            writeHelloWorld('gradle.pitest.test.hello')
+        writeHelloWorld('gradle.pitest.test.hello')
+
         when:
-            ExecutionResult result = runTasksWithFailure('pitest')
+        ExecutionResult result = runTasksWithFailure('pitest')
+
         then:
-            assertStdOutOrStdErrContainsGivenText(result, "No value has been specified for property 'targetClasses'")
+        assertStdOutOrStdErrContainsGivenText(result, "No value has been specified for property 'targetClasses'")
     }
+
 }

--- a/src/main/groovy/info/solidsoft/gradle/pitest/PitestPluginExtension.groovy
+++ b/src/main/groovy/info/solidsoft/gradle/pitest/PitestPluginExtension.groovy
@@ -302,14 +302,15 @@ class PitestPluginExtension {
     }
 
     private <T> SetProperty<T> nullSetPropertyOf(Project p, Class<T> clazz) {
-        return p.objects.setProperty(clazz).convention(p.providers.provider({ null }))
+        p.objects.setProperty(clazz).convention(p.providers.provider { null })
     }
 
     private <T> ListProperty<T> nullListPropertyOf(Project p, Class<T> clazz) {
-        return p.objects.listProperty(clazz).convention(p.providers.provider({ null }))
+        p.objects.listProperty(clazz).convention(p.providers.provider { null })
     }
 
     private <K, V> MapProperty<K, V> nullMapPropertyOf(Project p, Class<K> keyClazz, Class<V> valueClazz) {
-        return p.objects.mapProperty(keyClazz, valueClazz).convention(p.providers.provider({ null }))
+        p.objects.mapProperty(keyClazz, valueClazz).convention(p.providers.provider { null })
     }
+
 }

--- a/src/main/groovy/info/solidsoft/gradle/pitest/PitestPluginExtension.groovy
+++ b/src/main/groovy/info/solidsoft/gradle/pitest/PitestPluginExtension.groovy
@@ -302,15 +302,15 @@ class PitestPluginExtension {
     }
 
     private <T> SetProperty<T> nullSetPropertyOf(Project p, Class<T> clazz) {
-        p.objects.setProperty(clazz).convention(p.providers.provider { null })
+        return p.objects.setProperty(clazz).convention(p.providers.provider { null })
     }
 
     private <T> ListProperty<T> nullListPropertyOf(Project p, Class<T> clazz) {
-        p.objects.listProperty(clazz).convention(p.providers.provider { null })
+        return p.objects.listProperty(clazz).convention(p.providers.provider { null })
     }
 
     private <K, V> MapProperty<K, V> nullMapPropertyOf(Project p, Class<K> keyClazz, Class<V> valueClazz) {
-        p.objects.mapProperty(keyClazz, valueClazz).convention(p.providers.provider { null })
+        return p.objects.mapProperty(keyClazz, valueClazz).convention(p.providers.provider { null })
     }
 
 }

--- a/src/main/groovy/info/solidsoft/gradle/pitest/internal/GradleUtil.groovy
+++ b/src/main/groovy/info/solidsoft/gradle/pitest/internal/GradleUtil.groovy
@@ -7,6 +7,7 @@ import org.gradle.api.Project
 class GradleUtil {
 
     static boolean isPropertyNotDefinedOrFalse(Project project, String propertyName) {
-        return !project.hasProperty(propertyName) || project.findProperty(propertyName) == "false" || project.findProperty(propertyName) == false
+        !project.hasProperty(propertyName) || project.findProperty(propertyName) == 'false' || project.findProperty(propertyName) == false
     }
+
 }

--- a/src/main/groovy/info/solidsoft/gradle/pitest/internal/GradleUtil.groovy
+++ b/src/main/groovy/info/solidsoft/gradle/pitest/internal/GradleUtil.groovy
@@ -7,7 +7,7 @@ import org.gradle.api.Project
 class GradleUtil {
 
     static boolean isPropertyNotDefinedOrFalse(Project project, String propertyName) {
-        !project.hasProperty(propertyName) || project.findProperty(propertyName) == 'false' || project.findProperty(propertyName) == false
+        return !project.hasProperty(propertyName) || project.findProperty(propertyName) == "false" || project.findProperty(propertyName) == false
     }
 
 }

--- a/src/main/groovy/info/solidsoft/gradle/pitest/internal/GradleVersionEnforcer.groovy
+++ b/src/main/groovy/info/solidsoft/gradle/pitest/internal/GradleVersionEnforcer.groovy
@@ -25,7 +25,7 @@ class GradleVersionEnforcer {
     }
 
     static GradleVersionEnforcer defaultEnforcer(GradleVersion minimalSupportedVersion) {
-        new GradleVersionEnforcer(minimalSupportedVersion, DISABLE_GRADLE_VERSION_ENFORCEMENT_PROPERTY_NAME)
+        return new GradleVersionEnforcer(minimalSupportedVersion, DISABLE_GRADLE_VERSION_ENFORCEMENT_PROPERTY_NAME)
     }
 
     void failBuildWithMeaningfulErrorIfAppliedOnTooOldGradleVersion(Project project) {
@@ -34,7 +34,7 @@ class GradleVersionEnforcer {
                 "(detected: ${GradleVersion.current()}). Please upgrade your Gradle or downgrade the plugin version.")
 
             if (GradleUtil.isPropertyNotDefinedOrFalse(project, propertyNameToDisable)) {
-                log.warn('Aborting the build with the meaningful error message to prevent confusion. If you are sure it is an error, ' +
+                log.warn("Aborting the build with the meaningful error message to prevent confusion. If you are sure it is an error, " +
                     "please report it in the plugin issue tracker and in the meantime use '-D${propertyNameToDisable}' to disable this check")
 
                 throw new GradleException("'${PitestPlugin.PLUGIN_ID}' requires Gradle ${minimalSupportedVersion.version}")

--- a/src/main/groovy/info/solidsoft/gradle/pitest/internal/GradleVersionEnforcer.groovy
+++ b/src/main/groovy/info/solidsoft/gradle/pitest/internal/GradleVersionEnforcer.groovy
@@ -25,7 +25,7 @@ class GradleVersionEnforcer {
     }
 
     static GradleVersionEnforcer defaultEnforcer(GradleVersion minimalSupportedVersion) {
-        return new GradleVersionEnforcer(minimalSupportedVersion, DISABLE_GRADLE_VERSION_ENFORCEMENT_PROPERTY_NAME)
+        new GradleVersionEnforcer(minimalSupportedVersion, DISABLE_GRADLE_VERSION_ENFORCEMENT_PROPERTY_NAME)
     }
 
     void failBuildWithMeaningfulErrorIfAppliedOnTooOldGradleVersion(Project project) {
@@ -34,11 +34,12 @@ class GradleVersionEnforcer {
                 "(detected: ${GradleVersion.current()}). Please upgrade your Gradle or downgrade the plugin version.")
 
             if (GradleUtil.isPropertyNotDefinedOrFalse(project, propertyNameToDisable)) {
-                log.warn("Aborting the build with the meaningful error message to prevent confusion. If you are sure it is an error, " +
+                log.warn('Aborting the build with the meaningful error message to prevent confusion. If you are sure it is an error, ' +
                     "please report it in the plugin issue tracker and in the meantime use '-D${propertyNameToDisable}' to disable this check")
 
                 throw new GradleException("'${PitestPlugin.PLUGIN_ID}' requires Gradle ${minimalSupportedVersion.version}")
             }
         }
     }
+
 }

--- a/src/test/groovy/info/solidsoft/gradle/pitest/BasicProjectBuilderSpec.groovy
+++ b/src/test/groovy/info/solidsoft/gradle/pitest/BasicProjectBuilderSpec.groovy
@@ -15,6 +15,9 @@
  */
 package info.solidsoft.gradle.pitest
 
+import static info.solidsoft.gradle.pitest.PitestPlugin.PITEST_TASK_NAME
+
+import groovy.transform.CompileDynamic
 import groovy.transform.PackageScope
 import org.gradle.api.Project
 import org.gradle.api.Task
@@ -23,27 +26,26 @@ import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 
-import static info.solidsoft.gradle.pitest.PitestPlugin.PITEST_TASK_NAME
-
 /**
  * @see WithPitestTaskInitialization
  */
 @PackageScope
-abstract class BasicProjectBuilderSpec extends Specification {
+@CompileDynamic
+class BasicProjectBuilderSpec extends Specification {
 
     @Rule
-    public TemporaryFolder tmpProjectDir = new TemporaryFolder()
+    protected TemporaryFolder tmpProjectDir = new TemporaryFolder()
 
     protected Project project
     protected PitestPluginExtension pitestConfig
 
     //TODO: There is a regression in 2.14.1 with API jar regeneration for every test - https://discuss.gradle.org/t/performance-regression-in-projectbuilder-in-2-14-and-3-0/18956
     //https://github.com/gradle/gradle/commit/3216f07b3acb4cbbb8241d8a1d50b8db9940f37e
-    def setup() {
+    void setup() {
         project = ProjectBuilder.builder().withProjectDir(tmpProjectDir.root).build()
 
-        project.apply(plugin: "java")   //to add SourceSets
-        project.apply(plugin: "info.solidsoft.pitest")
+        project.pluginManager.apply('java')   //to add SourceSets
+        project.pluginManager.apply('info.solidsoft.pitest')
 
         pitestConfig = project.getExtensions().getByType(PitestPluginExtension)
 
@@ -54,6 +56,7 @@ abstract class BasicProjectBuilderSpec extends Specification {
         Set<Task> tasks = project.getTasksByName(PITEST_TASK_NAME, false) //forces "afterEvaluate"
         assert tasks?.size() == 1 : "Expected tasks: '$PITEST_TASK_NAME', All tasks: ${project.tasks}"
         assert tasks[0] instanceof PitestTask
-        return (PitestTask)tasks[0]
+        (PitestTask)tasks[0]
     }
+
 }

--- a/src/test/groovy/info/solidsoft/gradle/pitest/BasicProjectBuilderSpec.groovy
+++ b/src/test/groovy/info/solidsoft/gradle/pitest/BasicProjectBuilderSpec.groovy
@@ -56,7 +56,7 @@ class BasicProjectBuilderSpec extends Specification {
         Set<Task> tasks = project.getTasksByName(PITEST_TASK_NAME, false) //forces "afterEvaluate"
         assert tasks?.size() == 1 : "Expected tasks: '$PITEST_TASK_NAME', All tasks: ${project.tasks}"
         assert tasks[0] instanceof PitestTask
-        (PitestTask)tasks[0]
+        return (PitestTask)tasks[0]
     }
 
 }

--- a/src/test/groovy/info/solidsoft/gradle/pitest/PitestPluginClasspathFilteringSpec.groovy
+++ b/src/test/groovy/info/solidsoft/gradle/pitest/PitestPluginClasspathFilteringSpec.groovy
@@ -25,192 +25,157 @@ class PitestPluginClasspathFilteringSpec extends BasicProjectBuilderSpec {
     @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/52')
     void "should filter dynamic library '#libFileName' by default"() {
         given:
-        File libFile = addFileWithFileNameAsDependencyAndReturnAsFile(libFileName)
-
+            File libFile = addFileWithFileNameAsDependencyAndReturnAsFile(libFileName)
         and:
-        PitestTask task = getJustOnePitestTaskOrFail()
-
+            PitestTask task = getJustOnePitestTaskOrFail()
         expect:
-        !forceClasspathResolutionAndReturnIt(task).contains(libFile.path)
-
+            !forceClasspathResolutionAndReturnIt(task).contains(libFile.path)
         where:
-        libFileName << ['lib.so', 'win.dll', 'dyn.dylib']   //TODO: Add test with more than one element
+            libFileName << ['lib.so', 'win.dll', 'dyn.dylib']   //TODO: Add test with more than one element
     }
 
     void "should filter .pom file by default"() {
         given:
-        File pomFile = addFileWithFileNameAsDependencyAndReturnAsFile('foo.pom')
-
+            File pomFile = addFileWithFileNameAsDependencyAndReturnAsFile('foo.pom')
         and:
-        PitestTask task = getJustOnePitestTaskOrFail()
-
+            PitestTask task = getJustOnePitestTaskOrFail()
         expect:
-        !forceClasspathResolutionAndReturnIt(task).contains(pomFile.path)
+            !forceClasspathResolutionAndReturnIt(task).contains(pomFile.path)
     }
 
     void "should not filter regular dependency '#depFileName' by default"() {
         given:
-        File depFile = addFileWithFileNameAsDependencyAndReturnAsFile(depFileName)
-
+            File depFile = addFileWithFileNameAsDependencyAndReturnAsFile(depFileName)
         and:
-        PitestTask task = getJustOnePitestTaskOrFail()
-
+            PitestTask task = getJustOnePitestTaskOrFail()
         expect:
-        forceClasspathResolutionAndReturnIt(task).contains(depFile.path)
-
+            forceClasspathResolutionAndReturnIt(task).contains(depFile.path)
         where:
-        depFileName << ['foo.jar', 'foo.zip']
+            depFileName << ['foo.jar', 'foo.zip']
     }
 
     void "should not filter source set directory by default"() {
         given:
-        File testClassesDir = new File(new File(new File(new File(tmpProjectDir.root, 'build'), 'classes'), 'java'), 'test')
-
+            File testClassesDir = new File(new File(new File(new File(tmpProjectDir.root, 'build'), 'classes'), 'java'), 'test')
         and:
-        PitestTask task = getJustOnePitestTaskOrFail()
-
+            PitestTask task = getJustOnePitestTaskOrFail()
         expect:
-        forceClasspathResolutionAndReturnIt(task).contains(testClassesDir.path)
+            forceClasspathResolutionAndReturnIt(task).contains(testClassesDir.path)
     }
 
     void "should filter excluded dependencies remaining regular ones"() {
         given:
-        File depFile = addFileWithFileNameAsDependencyAndReturnAsFile('foo.jar')
-
+            File depFile = addFileWithFileNameAsDependencyAndReturnAsFile('foo.jar')
         and:
-        File libDepFile = addFileWithFileNameAsDependencyAndReturnAsFile('bar.so')
-
+            File libDepFile = addFileWithFileNameAsDependencyAndReturnAsFile('bar.so')
         and:
-        PitestTask task = getJustOnePitestTaskOrFail()
-
+            PitestTask task = getJustOnePitestTaskOrFail()
         expect:
-        forceClasspathResolutionAndReturnIt(task).contains(depFile.path)
-        !forceClasspathResolutionAndReturnIt(task).contains(libDepFile.path)
+            forceClasspathResolutionAndReturnIt(task).contains(depFile.path)
+            !forceClasspathResolutionAndReturnIt(task).contains(libDepFile.path)
     }
 
     @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/53')
-    @PendingFeature(exceptions = MissingMethodException, reason = 'Not supported in with ListProperty - https://github.com/gradle/gradle/issues/10475')
+    @PendingFeature(exceptions = MissingMethodException, reason = "Not supported in with ListProperty - https://github.com/gradle/gradle/issues/10475")
     void "should filter user defined extensions"() {
         given:
-        File depFile = addFileWithFileNameAsDependencyAndReturnAsFile('file.extra')
-
+            File depFile = addFileWithFileNameAsDependencyAndReturnAsFile('file.extra')
         and:
-        project.pitest.fileExtensionsToFilter += ['extra']
-
+            project.pitest.fileExtensionsToFilter += ['extra']
         and:
-        PitestTask task = getJustOnePitestTaskOrFail()
-
+            PitestTask task = getJustOnePitestTaskOrFail()
         expect:
-        !forceClasspathResolutionAndReturnIt(task).contains(depFile.path)
+            !forceClasspathResolutionAndReturnIt(task).contains(depFile.path)
     }
 
     @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/53')
     void "should filter user defined extensions (property syntax))"() {
         given:
-        File depFile = addFileWithFileNameAsDependencyAndReturnAsFile('file.extra')
-
+            File depFile = addFileWithFileNameAsDependencyAndReturnAsFile('file.extra')
         and:
-        project.pitest.fileExtensionsToFilter.addAll('extra')
-
+            project.pitest.fileExtensionsToFilter.addAll('extra')
         and:
-        PitestTask task = getJustOnePitestTaskOrFail()
-
+            PitestTask task = getJustOnePitestTaskOrFail()
         expect:
-        !forceClasspathResolutionAndReturnIt(task).contains(depFile.path)
+            !forceClasspathResolutionAndReturnIt(task).contains(depFile.path)
     }
 
     @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/53')
     void "should allow to override extensions filtered by default"() {
         given:
-        File depFile = addFileWithFileNameAsDependencyAndReturnAsFile('needed.so')
-
+            File depFile = addFileWithFileNameAsDependencyAndReturnAsFile('needed.so')
         and:
-        project.pitest.fileExtensionsToFilter = ['extra']
-
+            project.pitest.fileExtensionsToFilter = ['extra']
         and:
-        PitestTask task = getJustOnePitestTaskOrFail()
-
+            PitestTask task = getJustOnePitestTaskOrFail()
         expect:
-        forceClasspathResolutionAndReturnIt(task).contains(depFile.path)
+            forceClasspathResolutionAndReturnIt(task).contains(depFile.path)
     }
 
     @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/53')
-    @PendingFeature(exceptions = MissingMethodException, reason = 'Not supported in with ListProperty - https://github.com/gradle/gradle/issues/10475')
+    @PendingFeature(exceptions = MissingMethodException, reason = "Not supported in with ListProperty - https://github.com/gradle/gradle/issues/10475")
     void "should allow to provide extra extensions in addition to default ones"() {
         given:
-        File libDepFile = addFileWithFileNameAsDependencyAndReturnAsFile('default.so')
-        File extraDepFile = addFileWithFileNameAsDependencyAndReturnAsFile('file.extra')
-
+            File libDepFile = addFileWithFileNameAsDependencyAndReturnAsFile('default.so')
+            File extraDepFile = addFileWithFileNameAsDependencyAndReturnAsFile('file.extra')
         and:
-        project.pitest.fileExtensionsToFilter += ['extra']
-
+            project.pitest.fileExtensionsToFilter += ['extra']
         and:
-        PitestTask task = getJustOnePitestTaskOrFail()
-
+            PitestTask task = getJustOnePitestTaskOrFail()
         expect:
-        String resolvedPitClasspath = forceClasspathResolutionAndReturnIt(task)
-        !resolvedPitClasspath.contains(libDepFile.path)
-        !resolvedPitClasspath.contains(extraDepFile.path)
+            String resolvedPitClasspath = forceClasspathResolutionAndReturnIt(task)
+            !resolvedPitClasspath.contains(libDepFile.path)
+            !resolvedPitClasspath.contains(extraDepFile.path)
     }
 
     @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/53')
     void "should allow to provide extra extensions in addition to default ones (property syntax)"() {
         given:
-        File libDepFile = addFileWithFileNameAsDependencyAndReturnAsFile('default.so')
-        File extraDepFile = addFileWithFileNameAsDependencyAndReturnAsFile('file.extra')
-
+            File libDepFile = addFileWithFileNameAsDependencyAndReturnAsFile('default.so')
+            File extraDepFile = addFileWithFileNameAsDependencyAndReturnAsFile('file.extra')
         and:
-        project.pitest.fileExtensionsToFilter.addAll('extra')
-
+            project.pitest.fileExtensionsToFilter.addAll('extra')
         and:
-        PitestTask task = getJustOnePitestTaskOrFail()
-
+            PitestTask task = getJustOnePitestTaskOrFail()
         expect:
-        String resolvedPitClasspath = forceClasspathResolutionAndReturnIt(task)
-        !resolvedPitClasspath.contains(libDepFile.path)
-        !resolvedPitClasspath.contains(extraDepFile.path)
+            String resolvedPitClasspath = forceClasspathResolutionAndReturnIt(task)
+            !resolvedPitClasspath.contains(libDepFile.path)
+            !resolvedPitClasspath.contains(extraDepFile.path)
     }
 
     @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/53')
     void "should not fail on fileExtensionsToFilter set to null"() {
         given:
-        project.pitest.fileExtensionsToFilter = null
-
+            project.pitest.fileExtensionsToFilter = null
         and:
-        PitestTask task = getJustOnePitestTaskOrFail()
-
+            PitestTask task = getJustOnePitestTaskOrFail()
         when:
-        String resolvedPitClasspath = forceClasspathResolutionAndReturnIt(task)
-
+            String resolvedPitClasspath = forceClasspathResolutionAndReturnIt(task)
         then:
-        noExceptionThrown()
-
+            noExceptionThrown()
         and:
-        resolvedPitClasspath.contains('main')
+            resolvedPitClasspath.contains('main')
     }
 
     void "should filter dependencies also from 'api' configuration in java-library"() {
         given:
-        project.apply(plugin:'java-library')   //to add 'api' configuration
-
+            project.pluginManager.apply('java-library')   //to add 'api' configuration
         and:
-        File libFile = addFileWithFileNameAsDependencyAndReturnAsFile('lib.so', 'api')
-
+            File libFile = addFileWithFileNameAsDependencyAndReturnAsFile('lib.so', 'api')
         and:
-        PitestTask task = getJustOnePitestTaskOrFail()
-
+            PitestTask task = getJustOnePitestTaskOrFail()
         expect:
-        !forceClasspathResolutionAndReturnIt(task).contains(libFile.path)
+            !forceClasspathResolutionAndReturnIt(task).contains(libFile.path)
     }
 
     private String forceClasspathResolutionAndReturnIt(PitestTask task) {
-        task.taskArgumentsMap()['classPath']
+        return task.taskArgumentMap()['classPath']
     }
 
     private File addFileWithFileNameAsDependencyAndReturnAsFile(String depFileName, String configurationName = 'implementation') {
         File depFile = new File(tmpProjectDir.root, depFileName)
         project.dependencies.add(configurationName, project.files(depFile))
-        depFile
+        return depFile
     }
 
 }

--- a/src/test/groovy/info/solidsoft/gradle/pitest/PitestPluginClasspathFilteringSpec.groovy
+++ b/src/test/groovy/info/solidsoft/gradle/pitest/PitestPluginClasspathFilteringSpec.groovy
@@ -15,165 +15,202 @@
  */
 package info.solidsoft.gradle.pitest
 
-import spock.lang.Ignore
+import groovy.transform.CompileDynamic
 import spock.lang.Issue
 import spock.lang.PendingFeature
 
+@CompileDynamic
 class PitestPluginClasspathFilteringSpec extends BasicProjectBuilderSpec {
 
     @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/52')
-    def "should filter dynamic library '#libFileName' by default"() {
+    void "should filter dynamic library '#libFileName' by default"() {
         given:
-            File libFile = addFileWithFileNameAsDependencyAndReturnAsFile(libFileName)
+        File libFile = addFileWithFileNameAsDependencyAndReturnAsFile(libFileName)
+
         and:
-            PitestTask task = getJustOnePitestTaskOrFail()
+        PitestTask task = getJustOnePitestTaskOrFail()
+
         expect:
-            !forceClasspathResolutionAndReturnIt(task).contains(libFile.path)
+        !forceClasspathResolutionAndReturnIt(task).contains(libFile.path)
+
         where:
-            libFileName << ['lib.so', 'win.dll', 'dyn.dylib']   //TODO: Add test with more than one element
+        libFileName << ['lib.so', 'win.dll', 'dyn.dylib']   //TODO: Add test with more than one element
     }
 
-    def "should filter .pom file by default"() {
+    void "should filter .pom file by default"() {
         given:
-            File pomFile = addFileWithFileNameAsDependencyAndReturnAsFile('foo.pom')
+        File pomFile = addFileWithFileNameAsDependencyAndReturnAsFile('foo.pom')
+
         and:
-            PitestTask task = getJustOnePitestTaskOrFail()
+        PitestTask task = getJustOnePitestTaskOrFail()
+
         expect:
-            !forceClasspathResolutionAndReturnIt(task).contains(pomFile.path)
+        !forceClasspathResolutionAndReturnIt(task).contains(pomFile.path)
     }
 
-    def "should not filter regular dependency '#depFileName' by default"() {
+    void "should not filter regular dependency '#depFileName' by default"() {
         given:
-            File depFile = addFileWithFileNameAsDependencyAndReturnAsFile(depFileName)
+        File depFile = addFileWithFileNameAsDependencyAndReturnAsFile(depFileName)
+
         and:
-            PitestTask task = getJustOnePitestTaskOrFail()
+        PitestTask task = getJustOnePitestTaskOrFail()
+
         expect:
-            forceClasspathResolutionAndReturnIt(task).contains(depFile.path)
+        forceClasspathResolutionAndReturnIt(task).contains(depFile.path)
+
         where:
-            depFileName << ['foo.jar', 'foo.zip']
+        depFileName << ['foo.jar', 'foo.zip']
     }
 
-    def "should not filter source set directory by default"() {
+    void "should not filter source set directory by default"() {
         given:
-            File testClassesDir = new File(new File(new File(new File(tmpProjectDir.root, 'build'), 'classes'), 'java'), 'test')
+        File testClassesDir = new File(new File(new File(new File(tmpProjectDir.root, 'build'), 'classes'), 'java'), 'test')
+
         and:
-            PitestTask task = getJustOnePitestTaskOrFail()
+        PitestTask task = getJustOnePitestTaskOrFail()
+
         expect:
-            forceClasspathResolutionAndReturnIt(task).contains(testClassesDir.path)
+        forceClasspathResolutionAndReturnIt(task).contains(testClassesDir.path)
     }
 
-    def "should filter excluded dependencies remaining regular ones"() {
+    void "should filter excluded dependencies remaining regular ones"() {
         given:
-            File depFile = addFileWithFileNameAsDependencyAndReturnAsFile('foo.jar')
+        File depFile = addFileWithFileNameAsDependencyAndReturnAsFile('foo.jar')
+
         and:
-            File libDepFile = addFileWithFileNameAsDependencyAndReturnAsFile('bar.so')
+        File libDepFile = addFileWithFileNameAsDependencyAndReturnAsFile('bar.so')
+
         and:
-            PitestTask task = getJustOnePitestTaskOrFail()
+        PitestTask task = getJustOnePitestTaskOrFail()
+
         expect:
-            forceClasspathResolutionAndReturnIt(task).contains(depFile.path)
-            !forceClasspathResolutionAndReturnIt(task).contains(libDepFile.path)
+        forceClasspathResolutionAndReturnIt(task).contains(depFile.path)
+        !forceClasspathResolutionAndReturnIt(task).contains(libDepFile.path)
     }
 
     @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/53')
-    @PendingFeature(exceptions = MissingMethodException, reason = "Not supported in with ListProperty - https://github.com/gradle/gradle/issues/10475")
-    def "should filter user defined extensions"() {
+    @PendingFeature(exceptions = MissingMethodException, reason = 'Not supported in with ListProperty - https://github.com/gradle/gradle/issues/10475')
+    void "should filter user defined extensions"() {
         given:
-            File depFile = addFileWithFileNameAsDependencyAndReturnAsFile('file.extra')
+        File depFile = addFileWithFileNameAsDependencyAndReturnAsFile('file.extra')
+
         and:
-            project.pitest.fileExtensionsToFilter += ['extra']
+        project.pitest.fileExtensionsToFilter += ['extra']
+
         and:
-            PitestTask task = getJustOnePitestTaskOrFail()
+        PitestTask task = getJustOnePitestTaskOrFail()
+
         expect:
-            !forceClasspathResolutionAndReturnIt(task).contains(depFile.path)
+        !forceClasspathResolutionAndReturnIt(task).contains(depFile.path)
     }
 
     @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/53')
-    def "should filter user defined extensions (property syntax))"() {
+    void "should filter user defined extensions (property syntax))"() {
         given:
-            File depFile = addFileWithFileNameAsDependencyAndReturnAsFile('file.extra')
+        File depFile = addFileWithFileNameAsDependencyAndReturnAsFile('file.extra')
+
         and:
-            project.pitest.fileExtensionsToFilter.addAll('extra')
+        project.pitest.fileExtensionsToFilter.addAll('extra')
+
         and:
-            PitestTask task = getJustOnePitestTaskOrFail()
+        PitestTask task = getJustOnePitestTaskOrFail()
+
         expect:
-            !forceClasspathResolutionAndReturnIt(task).contains(depFile.path)
+        !forceClasspathResolutionAndReturnIt(task).contains(depFile.path)
     }
 
     @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/53')
-    def "should allow to override extensions filtered by default"() {
+    void "should allow to override extensions filtered by default"() {
         given:
-            File depFile = addFileWithFileNameAsDependencyAndReturnAsFile('needed.so')
+        File depFile = addFileWithFileNameAsDependencyAndReturnAsFile('needed.so')
+
         and:
-            project.pitest.fileExtensionsToFilter = ['extra']
+        project.pitest.fileExtensionsToFilter = ['extra']
+
         and:
-            PitestTask task = getJustOnePitestTaskOrFail()
+        PitestTask task = getJustOnePitestTaskOrFail()
+
         expect:
-            forceClasspathResolutionAndReturnIt(task).contains(depFile.path)
+        forceClasspathResolutionAndReturnIt(task).contains(depFile.path)
     }
 
     @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/53')
-    @PendingFeature(exceptions = MissingMethodException, reason = "Not supported in with ListProperty - https://github.com/gradle/gradle/issues/10475")
-    def "should allow to provide extra extensions in addition to default ones"() {
+    @PendingFeature(exceptions = MissingMethodException, reason = 'Not supported in with ListProperty - https://github.com/gradle/gradle/issues/10475')
+    void "should allow to provide extra extensions in addition to default ones"() {
         given:
-            File libDepFile = addFileWithFileNameAsDependencyAndReturnAsFile('default.so')
-            File extraDepFile = addFileWithFileNameAsDependencyAndReturnAsFile('file.extra')
+        File libDepFile = addFileWithFileNameAsDependencyAndReturnAsFile('default.so')
+        File extraDepFile = addFileWithFileNameAsDependencyAndReturnAsFile('file.extra')
+
         and:
-            project.pitest.fileExtensionsToFilter += ['extra']
+        project.pitest.fileExtensionsToFilter += ['extra']
+
         and:
-            PitestTask task = getJustOnePitestTaskOrFail()
+        PitestTask task = getJustOnePitestTaskOrFail()
+
         expect:
-            String resolvedPitClasspath = forceClasspathResolutionAndReturnIt(task)
-            !resolvedPitClasspath.contains(libDepFile.path)
-            !resolvedPitClasspath.contains(extraDepFile.path)
+        String resolvedPitClasspath = forceClasspathResolutionAndReturnIt(task)
+        !resolvedPitClasspath.contains(libDepFile.path)
+        !resolvedPitClasspath.contains(extraDepFile.path)
     }
 
     @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/53')
-    def "should allow to provide extra extensions in addition to default ones (property syntax)"() {
+    void "should allow to provide extra extensions in addition to default ones (property syntax)"() {
         given:
-            File libDepFile = addFileWithFileNameAsDependencyAndReturnAsFile('default.so')
-            File extraDepFile = addFileWithFileNameAsDependencyAndReturnAsFile('file.extra')
+        File libDepFile = addFileWithFileNameAsDependencyAndReturnAsFile('default.so')
+        File extraDepFile = addFileWithFileNameAsDependencyAndReturnAsFile('file.extra')
+
         and:
-            project.pitest.fileExtensionsToFilter.addAll('extra')
+        project.pitest.fileExtensionsToFilter.addAll('extra')
+
         and:
-            PitestTask task = getJustOnePitestTaskOrFail()
+        PitestTask task = getJustOnePitestTaskOrFail()
+
         expect:
-            String resolvedPitClasspath = forceClasspathResolutionAndReturnIt(task)
-            !resolvedPitClasspath.contains(libDepFile.path)
-            !resolvedPitClasspath.contains(extraDepFile.path)
+        String resolvedPitClasspath = forceClasspathResolutionAndReturnIt(task)
+        !resolvedPitClasspath.contains(libDepFile.path)
+        !resolvedPitClasspath.contains(extraDepFile.path)
     }
 
     @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/53')
-    def "should not fail on fileExtensionsToFilter set to null"() {
+    void "should not fail on fileExtensionsToFilter set to null"() {
         given:
-            project.pitest.fileExtensionsToFilter = null
+        project.pitest.fileExtensionsToFilter = null
+
         and:
-            PitestTask task = getJustOnePitestTaskOrFail()
+        PitestTask task = getJustOnePitestTaskOrFail()
+
         when:
-            String resolvedPitClasspath = forceClasspathResolutionAndReturnIt(task)
+        String resolvedPitClasspath = forceClasspathResolutionAndReturnIt(task)
+
         then:
-            noExceptionThrown()
+        noExceptionThrown()
+
         and:
-            resolvedPitClasspath.contains('main')
+        resolvedPitClasspath.contains('main')
     }
 
-    def "should filter dependencies also from 'api' configuration in java-library"() {
+    void "should filter dependencies also from 'api' configuration in java-library"() {
         given:
-            project.apply(plugin: "java-library")   //to add 'api' configuration
+        project.apply(plugin:'java-library')   //to add 'api' configuration
+
         and:
-            File libFile = addFileWithFileNameAsDependencyAndReturnAsFile('lib.so', 'api')
+        File libFile = addFileWithFileNameAsDependencyAndReturnAsFile('lib.so', 'api')
+
         and:
-            PitestTask task = getJustOnePitestTaskOrFail()
+        PitestTask task = getJustOnePitestTaskOrFail()
+
         expect:
-            !forceClasspathResolutionAndReturnIt(task).contains(libFile.path)
+        !forceClasspathResolutionAndReturnIt(task).contains(libFile.path)
     }
 
     private String forceClasspathResolutionAndReturnIt(PitestTask task) {
-        return task.createTaskArgumentMap()['classPath']
+        task.taskArgumentsMap()['classPath']
     }
 
     private File addFileWithFileNameAsDependencyAndReturnAsFile(String depFileName, String configurationName = 'implementation') {
         File depFile = new File(tmpProjectDir.root, depFileName)
         project.dependencies.add(configurationName, project.files(depFile))
-        return depFile
+        depFile
     }
+
 }

--- a/src/test/groovy/info/solidsoft/gradle/pitest/PitestPluginTargetClassesTest.groovy
+++ b/src/test/groovy/info/solidsoft/gradle/pitest/PitestPluginTargetClassesTest.groovy
@@ -15,55 +15,64 @@
  */
 package info.solidsoft.gradle.pitest
 
+import groovy.transform.CompileDynamic
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 
+@CompileDynamic
 class PitestPluginTargetClassesTest extends Specification {
 
     private Project project
 
-    def setup() {
+    void setup() {
         project = ProjectBuilder.builder().build()
-        project.apply(plugin: "java")
-        project.apply(plugin: "info.solidsoft.pitest")
+        project.pluginManager.apply('java')
+        project.pluginManager.apply('info.solidsoft.pitest')
     }
 
-    def "take target classes from pitest configuration closure"() {
+    void "take target classes from pitest configuration closure"() {
         given:
-            project.pitest.targetClasses = ["foo"]
+        project.pitest.targetClasses = ['foo']
+
         when:
-            Set<Task> tasks = project.getTasksByName(PitestPlugin.PITEST_TASK_NAME, false)
+        Set<Task> tasks = project.getTasksByName(PitestPlugin.PITEST_TASK_NAME, false)
+
         then:
-            assertOnePitestTaskWithGivenTargetClasses(tasks, ["foo"] as Set)
+        assertOnePitestTaskWithGivenTargetClasses(tasks, ['foo'] as Set)
     }
 
-    def "set target classes to project group if defined"() {
+    void "set target classes to project group if defined"() {
         given:
-            project.group = "group"
+        project.group = 'group'
+
         when:
-            Set<Task> tasks = project.getTasksByName(PitestPlugin.PITEST_TASK_NAME, false)
+        Set<Task> tasks = project.getTasksByName(PitestPlugin.PITEST_TASK_NAME, false)
+
         then:
-            assertOnePitestTaskWithGivenTargetClasses(tasks, ["group.*"] as Set)
+        assertOnePitestTaskWithGivenTargetClasses(tasks, ['group.*'] as Set)
     }
 
-    def "override default target classes from project group if defined by user"() {
+    void "override default target classes from project group if defined by user"() {
         given:
-            project.group = "group"
-            project.pitest.targetClasses = ["target.classes"]
+        project.group = 'group'
+        project.pitest.targetClasses = ['target.classes']
+
         when:
-            Set<Task> tasks = project.getTasksByName(PitestPlugin.PITEST_TASK_NAME, false)
+        Set<Task> tasks = project.getTasksByName(PitestPlugin.PITEST_TASK_NAME, false)
+
         then:
-            assertOnePitestTaskWithGivenTargetClasses(tasks, ["target.classes"] as Set)
+        assertOnePitestTaskWithGivenTargetClasses(tasks, ['target.classes'] as Set)
     }
 
     //Only imitation of testing Gradle validation exception
-    def "keep classes to mutate by PIT not set if project group not defined and not explicit set targetClasses parameter"() {
+    void "keep classes to mutate by PIT not set if project group not defined and not explicit set targetClasses parameter"() {
         when:
-            Set<Task> tasks = project.getTasksByName(PitestPlugin.PITEST_TASK_NAME, false)
+        Set<Task> tasks = project.getTasksByName(PitestPlugin.PITEST_TASK_NAME, false)
+
         then:
-            assertOnePitestTaskWithGivenTargetClasses(tasks, null)
+        assertOnePitestTaskWithGivenTargetClasses(tasks, null)
     }
 
     //Test case "throw Gradle exception if project group not defined and not explicit set targetClasses parameter" implemented as functional test
@@ -74,4 +83,5 @@ class PitestPluginTargetClassesTest extends Specification {
         PitestTask pitestTask = (PitestTask) tasks.first()
         assert pitestTask.getTargetClasses().getOrNull() == expectedTargetClasses
     }
+
 }

--- a/src/test/groovy/info/solidsoft/gradle/pitest/PitestPluginTargetClassesTest.groovy
+++ b/src/test/groovy/info/solidsoft/gradle/pitest/PitestPluginTargetClassesTest.groovy
@@ -34,45 +34,38 @@ class PitestPluginTargetClassesTest extends Specification {
 
     void "take target classes from pitest configuration closure"() {
         given:
-        project.pitest.targetClasses = ['foo']
-
+            project.pitest.targetClasses = ["foo"]
         when:
-        Set<Task> tasks = project.getTasksByName(PitestPlugin.PITEST_TASK_NAME, false)
-
+            Set<Task> tasks = project.getTasksByName(PitestPlugin.PITEST_TASK_NAME, false)
         then:
-        assertOnePitestTaskWithGivenTargetClasses(tasks, ['foo'] as Set)
+            assertOnePitestTaskWithGivenTargetClasses(tasks, ["foo"] as Set)
     }
 
     void "set target classes to project group if defined"() {
         given:
-        project.group = 'group'
-
+            project.group = "group"
         when:
-        Set<Task> tasks = project.getTasksByName(PitestPlugin.PITEST_TASK_NAME, false)
-
+            Set<Task> tasks = project.getTasksByName(PitestPlugin.PITEST_TASK_NAME, false)
         then:
-        assertOnePitestTaskWithGivenTargetClasses(tasks, ['group.*'] as Set)
+            assertOnePitestTaskWithGivenTargetClasses(tasks, ["group.*"] as Set)
     }
 
     void "override default target classes from project group if defined by user"() {
         given:
-        project.group = 'group'
-        project.pitest.targetClasses = ['target.classes']
-
+            project.group = "group"
+            project.pitest.targetClasses = ["target.classes"]
         when:
-        Set<Task> tasks = project.getTasksByName(PitestPlugin.PITEST_TASK_NAME, false)
-
+            Set<Task> tasks = project.getTasksByName(PitestPlugin.PITEST_TASK_NAME, false)
         then:
-        assertOnePitestTaskWithGivenTargetClasses(tasks, ['target.classes'] as Set)
+            assertOnePitestTaskWithGivenTargetClasses(tasks, ["target.classes"] as Set)
     }
 
     //Only imitation of testing Gradle validation exception
     void "keep classes to mutate by PIT not set if project group not defined and not explicit set targetClasses parameter"() {
         when:
-        Set<Task> tasks = project.getTasksByName(PitestPlugin.PITEST_TASK_NAME, false)
-
+            Set<Task> tasks = project.getTasksByName(PitestPlugin.PITEST_TASK_NAME, false)
         then:
-        assertOnePitestTaskWithGivenTargetClasses(tasks, null)
+            assertOnePitestTaskWithGivenTargetClasses(tasks, null)
     }
 
     //Test case "throw Gradle exception if project group not defined and not explicit set targetClasses parameter" implemented as functional test

--- a/src/test/groovy/info/solidsoft/gradle/pitest/PitestPluginTest.groovy
+++ b/src/test/groovy/info/solidsoft/gradle/pitest/PitestPluginTest.groovy
@@ -26,35 +26,28 @@ class PitestPluginTest extends Specification {
 
     void "add pitest task to java project in proper group"() {
         given:
-        Project project = ProjectBuilder.builder().build()
-        project.pluginManager.apply('java')   //to add SourceSets
-
+            Project project = ProjectBuilder.builder().build()
+            project.pluginManager.apply('java')   //to add SourceSets
         when:
-        project.pluginManager.apply('info.solidsoft.pitest')
-
+            project.pluginManager.apply('info.solidsoft.pitest')
         then:
-        project.plugins.hasPlugin(PitestPlugin)
-        assertThatTasksAreInGroup(project, [PitestPlugin.PITEST_TASK_NAME], PitestPlugin.PITEST_TASK_GROUP)
+            project.plugins.hasPlugin(PitestPlugin)
+            assertThatTasksAreInGroup(project, [PitestPlugin.PITEST_TASK_NAME], PitestPlugin.PITEST_TASK_GROUP)
     }
 
     void "do nothing if Java plugin is not applied but react to it becoming applied"() {
         given:
-        Project project = ProjectBuilder.builder().build()
-
+            Project project = ProjectBuilder.builder().build()
         expect:
-        !project.plugins.hasPlugin('java')
-
+            !project.plugins.hasPlugin("java")
         when:
-        project.pluginManager.apply('info.solidsoft.pitest')
-
+            project.pluginManager.apply('info.solidsoft.pitest')
         then:
-        project.tasks.withType(PitestTask).isEmpty()
-
+            project.tasks.withType(PitestTask).isEmpty()
         when:
-        project.pluginManager.apply('java')
-
+            project.pluginManager.apply('java')
         then:
-        !project.tasks.withType(PitestTask).isEmpty()
+            !project.tasks.withType(PitestTask).isEmpty()
     }
 
     void assertThatTasksAreInGroup(Project project, List<String> taskNames, String group) {

--- a/src/test/groovy/info/solidsoft/gradle/pitest/PitestPluginTest.groovy
+++ b/src/test/groovy/info/solidsoft/gradle/pitest/PitestPluginTest.groovy
@@ -15,38 +15,46 @@
  */
 package info.solidsoft.gradle.pitest
 
-import spock.lang.Issue
+import groovy.transform.CompileDynamic
 import spock.lang.Specification
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.gradle.api.Task
 
+@CompileDynamic
 class PitestPluginTest extends Specification {
 
-    def "add pitest task to java project in proper group"() {
+    void "add pitest task to java project in proper group"() {
         given:
-            Project project = ProjectBuilder.builder().build()
-            project.apply(plugin: "java")   //to add SourceSets
+        Project project = ProjectBuilder.builder().build()
+        project.pluginManager.apply('java')   //to add SourceSets
+
         when:
-            project.apply(plugin: "info.solidsoft.pitest")
+        project.pluginManager.apply('info.solidsoft.pitest')
+
         then:
-            project.plugins.hasPlugin(PitestPlugin)
-            assertThatTasksAreInGroup(project, [PitestPlugin.PITEST_TASK_NAME], PitestPlugin.PITEST_TASK_GROUP)
+        project.plugins.hasPlugin(PitestPlugin)
+        assertThatTasksAreInGroup(project, [PitestPlugin.PITEST_TASK_NAME], PitestPlugin.PITEST_TASK_GROUP)
     }
 
-    def "do nothing if Java plugin is not applied but react to it becoming applied"() {
+    void "do nothing if Java plugin is not applied but react to it becoming applied"() {
         given:
-            Project project = ProjectBuilder.builder().build()
+        Project project = ProjectBuilder.builder().build()
+
         expect:
-            !project.plugins.hasPlugin("java")
+        !project.plugins.hasPlugin('java')
+
         when:
-            project.apply(plugin: "info.solidsoft.pitest");
+        project.pluginManager.apply('info.solidsoft.pitest')
+
         then:
-            project.tasks.withType(PitestTask).isEmpty()
+        project.tasks.withType(PitestTask).isEmpty()
+
         when:
-            project.apply(plugin: "java");
+        project.pluginManager.apply('java')
+
         then:
-            !project.tasks.withType(PitestTask).isEmpty()
+        !project.tasks.withType(PitestTask).isEmpty()
     }
 
     void assertThatTasksAreInGroup(Project project, List<String> taskNames, String group) {
@@ -56,4 +64,5 @@ class PitestPluginTest extends Specification {
             assert task.group == group
         }
     }
+
 }

--- a/src/test/groovy/info/solidsoft/gradle/pitest/PitestPluginTypesConversionTest.groovy
+++ b/src/test/groovy/info/solidsoft/gradle/pitest/PitestPluginTypesConversionTest.groovy
@@ -22,18 +22,16 @@ class PitestPluginTypesConversionTest extends BasicProjectBuilderSpec implements
 
     void "accept BigDecimal as timeoutFactor configuration parameter"() {
         given:
-        project.pitest.timeoutFactor = 1.23
-
+            project.pitest.timeoutFactor = 1.23
         expect:
-        task.timeoutFactor.get() == 1.23
+            task.timeoutFactor.get() == 1.23
     }
 
     void "accept String as timeoutFactor configuration parameter"() {
         given:
-        project.pitest.timeoutFactor = '1.23'
-
+            project.pitest.timeoutFactor = "1.23"
         expect:
-        task.timeoutFactor.get() == 1.23
+            task.timeoutFactor.get() == 1.23
     }
 
 }

--- a/src/test/groovy/info/solidsoft/gradle/pitest/PitestPluginTypesConversionTest.groovy
+++ b/src/test/groovy/info/solidsoft/gradle/pitest/PitestPluginTypesConversionTest.groovy
@@ -15,19 +15,25 @@
  */
 package info.solidsoft.gradle.pitest
 
+import groovy.transform.CompileDynamic
+
+@CompileDynamic
 class PitestPluginTypesConversionTest extends BasicProjectBuilderSpec implements WithPitestTaskInitialization {
 
-    def "accept BigDecimal as timeoutFactor configuration parameter"() {
+    void "accept BigDecimal as timeoutFactor configuration parameter"() {
         given:
-            project.pitest.timeoutFactor = 1.23
+        project.pitest.timeoutFactor = 1.23
+
         expect:
-            task.timeoutFactor.get() == 1.23
+        task.timeoutFactor.get() == 1.23
     }
 
-    def "accept String as timeoutFactor configuration parameter"() {
+    void "accept String as timeoutFactor configuration parameter"() {
         given:
-            project.pitest.timeoutFactor = "1.23"
+        project.pitest.timeoutFactor = '1.23'
+
         expect:
-            task.timeoutFactor.get() == 1.23
+        task.timeoutFactor.get() == 1.23
     }
+
 }

--- a/src/test/groovy/info/solidsoft/gradle/pitest/PitestTaskConfigurationSpec.groovy
+++ b/src/test/groovy/info/solidsoft/gradle/pitest/PitestTaskConfigurationSpec.groovy
@@ -21,7 +21,8 @@ import spock.lang.Issue
 @CompileDynamic
 class PitestTaskConfigurationSpec extends BasicProjectBuilderSpec implements WithPitestTaskInitialization {
 
-    @SuppressWarnings('JUnitPublicField') //public to be used also in functional tests
+    //public to be used also in functional tests
+    @SuppressWarnings("JUnitPublicField")
     public static final List<String> PIT_PARAMETERS_NAMES_NOT_SET_BY_DEFAULT = ['classPathFile',
                                                                                 'features',
                                                                                 'excludedTestClasses',
@@ -30,7 +31,7 @@ class PitestTaskConfigurationSpec extends BasicProjectBuilderSpec implements Wit
                                                                                 'threads',
                                                                                 'mutateStaticInits',
                                                                                 'includeJarFiles',
-                                                                                'mutators',
+                                                                                "mutators",
                                                                                 'excludedMethods',
                                                                                 'excludedClasses',
                                                                                 'excludedTestClasses',
@@ -63,169 +64,154 @@ class PitestTaskConfigurationSpec extends BasicProjectBuilderSpec implements Wit
 
     void "should pass additional classpath to PIT using classPathFile parameter instead of classPath if configured"() {
         given:
-        project.pitest.useClasspathFile = true
-
+            project.pitest.useClasspathFile = true
         and:
-        new File(project.buildDir.absolutePath).mkdir() //in ProjectBuilder "build" directory is not created by default
-
+            new File(project.buildDir.absolutePath).mkdir() //in ProjectBuilder "build" directory is not created by default
         expect:
-        task.taskArgumentsMap()['classPathFile'] == new File(project.buildDir, 'pitClasspath').absolutePath
-        !task.taskArgumentsMap()['classPath']
+            task.taskArgumentMap()['classPathFile'] == new File(project.buildDir, "pitClasspath").absolutePath
+            !task.taskArgumentMap()['classPath']
     }
 
     void "should pass features configuration to PIT"() {
         given:
-        project.pitest.features = ['-FOO', '+BAR(a[1] a[2])']
-
+            project.pitest.features = ["-FOO", "+BAR(a[1] a[2])"]
         expect:
-        task.taskArgumentsMap()['features'] == '-FOO,+BAR(a[1] a[2])'
+            task.taskArgumentMap()['features'] == "-FOO,+BAR(a[1] a[2])"
     }
 
     void "should pass additional features alone if features not set in configuration"() {
         given:
-        getJustOnePitestTaskOrFail().additionalFeatures = ['+XYZ', '-ABC']
-
+            getJustOnePitestTaskOrFail().additionalFeatures = ['+XYZ', '-ABC']
         expect:
-        task.taskArgumentsMap()['features'] == '+XYZ,-ABC'
+            task.taskArgumentMap()['features'] == "+XYZ,-ABC"
     }
 
     void "should add additional features to those defined in configuration"() {
         given:
-        project.pitest.features = ['-FOO', '+BAR']
-        getJustOnePitestTaskOrFail().additionalFeatures = ['+XYZ', '-ABC']
-
+            project.pitest.features = ["-FOO", "+BAR"]
+            getJustOnePitestTaskOrFail().additionalFeatures = ['+XYZ', '-ABC']
         expect:
-        task.taskArgumentsMap()['features'] == '-FOO,+BAR,+XYZ,-ABC'
+            task.taskArgumentMap()['features'] == "-FOO,+BAR,+XYZ,-ABC"
     }
 
     void "should not pass features configuration to PIT if not set in configuration or via option"() {
         //Intentional duplication with generic parametrized tests to emphasis requirement
         expect:
-        task.taskArgumentsMap()['featues'] == null
+            task.taskArgumentMap()['featues'] == null
     }
 
     void "should not pass to PIT parameter '#paramName' by default if not set explicitly"() {
         expect:
-        !task.taskArgumentsMap().containsKey(paramName)
-
+            !task.taskArgumentMap().containsKey(paramName)
         where:
-        //It would be best to have it generated automatically based. However, mapping between task parameters and map passed to PIT is not 1-to-1
-        paramName << PIT_PARAMETERS_NAMES_NOT_SET_BY_DEFAULT
+            //It would be best to have it generated automatically based. However, mapping between task parameters and map passed to PIT is not 1-to-1
+            paramName << PIT_PARAMETERS_NAMES_NOT_SET_BY_DEFAULT
     }
 
     //TODO: Run PIT with those values to detect removed properties and typos
     void "should pass plugin configuration (#configParamName) from Gradle to PIT"() {
         given:
-        project.pitest."${configParamName}" = gradleConfigValue
-
+            project.pitest."${configParamName}" = gradleConfigValue
         expect:
-        task.taskArgumentsMap()[configParamName] == expectedPitConfigValue
-        // TODO: Move timeoutConst to separate test
-
+            task.taskArgumentMap()[configParamName] == expectedPitConfigValue
+            // TODO: Move timeoutConst to separate test
         where:
-        //pitConfigParamName value taken from gradleConfigParamName if set to null
-        configParamName          | gradleConfigValue                            | expectedPitConfigValue
-        'testPlugin'             | 'testng'                                     | 'testng'
-        'reportDir'              | new File('//tmp//foo')                       | new File('//tmp//foo').path    //due to issues on Windows
-        'targetClasses'          | ['a', 'b']                                   | 'a,b'
-        'targetTests'            | ['t1', 't2']                                 | 't1,t2'
-        'dependencyDistance'     | 42                                           | '42'
-        'threads'                | 42                                           | '42'
-        'mutateStaticInits'      | true                                         | 'true' //??
-        'includeJarFiles'        | false                                        | 'false'
-        'mutators'               | ['MUTATOR_X', 'MUTATOR_Y']                   | 'MUTATOR_X,MUTATOR_Y'
-        'excludedMethods'        | ['methodX', 'methodY']                       | 'methodX,methodY'
-        'excludedClasses'        | ['classX', 'foo.classY']                     | 'classX,foo.classY'
-        'excludedTestClasses'    | ['classX', 'foo.classY']                     | 'classX,foo.classY'
-        'avoidCallsTo'           | ['callX', 'foo.callY']                       | 'callX,foo.callY'
-        'verbose'                | true                                         | 'true'
-        'timeoutFactor'          | 1.25                                         | '1.25'
-        'maxMutationsPerClass'   | 25                                           | '25'
-        'jvmArgs'                | ['-Xmx250m', '-Xms100m']                     | '-Xmx250m,-Xms100m'
-        'outputFormats'          | ['HTML', 'CSV']                              | 'HTML,CSV'
-        'failWhenNoMutations'    | false                                        | 'false'
-        'skipFailingTests'       | true                                         | 'true'
-        'includedGroups'         | ['Group1', 'Group2']                         | 'Group1,Group2'
-        'excludedGroups'         | ['Group1', 'Group2']                         | 'Group1,Group2'
-        'includedTestMethods'    | ['method1', 'method2']                       | 'method1,method2'
-        'detectInlinedCode'      | true                                         | 'true'
-        'timestampedReports'     | true                                         | 'true'
-        'mutationThreshold'      | 90                                           | '90'
-        'coverageThreshold'      | 95                                           | '95'
-        'mutationEngine'         | 'gregor2'                                    | 'gregor2'
-        //sourceSet x2
-        'exportLineCoverage'     | true                                         | 'true'
-        'jvmPath'                | new File('//opt//jvm15//')                   | new File('//opt//jvm15//').path
-        //mainProcessJvmArgs?
+            //pitConfigParamName value taken from gradleConfigParamName if set to null
+            configParamName          | gradleConfigValue                            | expectedPitConfigValue
+            "testPlugin"             | "testng"                                     | "testng"
+            "reportDir"              | new File("//tmp//foo")                       | new File("//tmp//foo").path    //due to issues on Windows
+            "targetClasses"          | ["a", "b"]                                   | "a,b"
+            "targetTests"            | ["t1", "t2"]                                 | "t1,t2"
+            "dependencyDistance"     | 42                                           | "42"
+            "threads"                | 42                                           | "42"
+            "mutateStaticInits"      | true                                         | "true" //???
+            "includeJarFiles"        | false                                        | "false"
+            "mutators"               | ["MUTATOR_X", "MUTATOR_Y"]                   | "MUTATOR_X,MUTATOR_Y"
+            "excludedMethods"        | ["methodX", "methodY"]                       | "methodX,methodY"
+            "excludedClasses"        | ["classX", "foo.classY"]                     | "classX,foo.classY"
+            "excludedTestClasses"    | ["classX", "foo.classY"]                     | "classX,foo.classY"
+            "avoidCallsTo"           | ["callX", "foo.callY"]                       | "callX,foo.callY"
+            "verbose"                | true                                         | "true"
+            "timeoutFactor"          | 1.25                                         | "1.25"
+            "maxMutationsPerClass"   | 25                                           | "25"
+            "jvmArgs"                | ["-Xmx250m", "-Xms100m"]                     | "-Xmx250m,-Xms100m"
+            "outputFormats"          | ["HTML", "CSV"]                              | "HTML,CSV"
+            "failWhenNoMutations"    | false                                        | "false"
+            "skipFailingTests"       | true                                         | "true"
+            "includedGroups"         | ["Group1", "Group2"]                         | "Group1,Group2"
+            "excludedGroups"         | ["Group1", "Group2"]                         | "Group1,Group2"
+            "includedTestMethods"    | ["method1", "method2"]                       | "method1,method2"
+            "detectInlinedCode"      | true                                         | "true"
+            "timestampedReports"     | true                                         | "true"
+            "mutationThreshold"      | 90                                           | "90"
+            "coverageThreshold"      | 95                                           | "95"
+            "mutationEngine"         | "gregor2"                                    | "gregor2"
+            //sourceSet x2
+            "exportLineCoverage"     | true                                         | "true"
+            "jvmPath"                | new File("//opt//jvm15//")                   | new File("//opt//jvm15//").path
+            //mainProcessJvmArgs?
 //            "pluginConfiguration"    | ["plugin1.key1": "v1", "plugin1.key2": "v2"] || "?"   //Tested separately
-        'maxSurviving'           | 20                                           | '20'
-        'useClasspathJar'        | true                                         | 'true'
+            "maxSurviving"           | 20                                           | "20"
+            "useClasspathJar"        | true                                         | "true"
 //            "useClasspathFile"       | true                                         || "false"    //TODO
-        'features'               | ['-FOO', '+BAR(a[1] a[2])']                  | '-FOO,+BAR(a[1] a[2])'
+            "features"               | ["-FOO", "+BAR(a[1] a[2])"]                  | "-FOO,+BAR(a[1] a[2])"
 //            "fileExtensionsToFilter" | ["zip", "xxx"]                               || "*.zip,*.xxx"  //not passed to PIT
-        'historyInputLocation'   | new File('//tmp//hi')                        | new File('//tmp//hi').path
-        'historyOutputLocation'  | new File('//tmp//ho')                        | new File('//tmp//ho').path
+            "historyInputLocation"   | new File("//tmp//hi")                        | new File("//tmp//hi").path
+            "historyOutputLocation"  | new File("//tmp//ho")                        | new File("//tmp//ho").path
     }
 
     void "should pass plugin configuration (#gradleConfigParamName) from Gradle to PIT (overridden name)"() {
         given:
-        project.pitest."${gradleConfigParamName}" = gradleConfigValue
-
+            project.pitest."${gradleConfigParamName}" = gradleConfigValue
         expect:
-        task.taskArgumentsMap()[pitConfigParamName ?: gradleConfigParamName] == expectedPitConfigValue
-
+            task.taskArgumentMap()[pitConfigParamName ?: gradleConfigParamName] == expectedPitConfigValue
         where:
-        //pitConfigParamName value taken from gradleConfigParamName if set to null
-        gradleConfigParamName  | gradleConfigValue | pitConfigParamName | expectedPitConfigValue
-        'timeoutConstInMillis' | 100               | 'timeoutConst'     | '100'
+            //pitConfigParamName value taken from gradleConfigParamName if set to null
+            gradleConfigParamName  | gradleConfigValue | pitConfigParamName | expectedPitConfigValue
+            "timeoutConstInMillis" | 100               | "timeoutConst"     | "100"
 //            "useClasspathFile" | true               | "classPathFile"     || "?"    //tested separately
     }
 
     void "should pass plugin configuration (mutableCodePaths) from Gradle to PIT"() {
         given:
-        project.pitest.additionalMutableCodePaths = [new File('//tmp//p1'), new File('//tmp//p2')]
-
+            project.pitest.additionalMutableCodePaths = [new File("//tmp//p1"), new File("//tmp//p2")]
         expect:
-        task.taskArgumentsMap()['mutableCodePaths'].contains("${new File('//tmp//p1').path},${new File('//tmp//p2').path}")
+            task.taskArgumentMap()["mutableCodePaths"].contains("${new File("//tmp//p1").path},${new File("//tmp//p2").path}")
     }
 
-    @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/144')
+    @Issue("https://github.com/szpak/gradle-pitest-plugin/issues/144")
     void "should set targetTests to targetClasses by default if not defined in configuration"() {
         when:
-        project.pitest.targetClasses = ['myClasses.*']
-
+            project.pitest.targetClasses = ["myClasses.*"]
         then:
-        task.taskArgumentsMap()['targetTests'] == 'myClasses.*'
+            task.taskArgumentMap()['targetTests'] == "myClasses.*"
     }
 
-    @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/144')
+    @Issue("https://github.com/szpak/gradle-pitest-plugin/issues/144")
     void "should set targetTests to configuration defined value"() {
         when:
-        project.pitest.targetClasses = ['myClasses.*']
-        project.pitest.targetTests = ['myClasses.tests.*']
-
+            project.pitest.targetClasses = ["myClasses.*"]
+            project.pitest.targetTests = ["myClasses.tests.*"]
         then:
-        task.taskArgumentsMap()['targetTests'] == 'myClasses.tests.*'
+            task.taskArgumentMap()['targetTests'] == "myClasses.tests.*"
     }
 
-    @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/143')
+    @Issue("https://github.com/szpak/gradle-pitest-plugin/issues/143")
     void "should override explicitly defined in configuration targetTests from command line"() {
         given:
-        project.pitest.targetTests = ['com.foobar.*']
-        getJustOnePitestTaskOrFail().overriddenTargetTests = ['com.example.a.*', 'com.example.b.*']
-
+            project.pitest.targetTests = ["com.foobar.*"]
+            getJustOnePitestTaskOrFail().overriddenTargetTests = ["com.example.a.*", "com.example.b.*"]
         expect:
-        task.taskArgumentsMap()['targetTests'] == 'com.example.a.*,com.example.b.*'
+            task.taskArgumentMap()['targetTests'] == "com.example.a.*,com.example.b.*"
     }
 
-    @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/143')
+    @Issue("https://github.com/szpak/gradle-pitest-plugin/issues/143")
     void "should override targetTests inferred from targetClasses from command line"() {
         given:
-        project.pitest.targetClasses = ['com.foobar.*']
-        getJustOnePitestTaskOrFail().overriddenTargetTests = ['com.example.a.*', 'com.example.b.*']
-
+            project.pitest.targetClasses = ["com.foobar.*"]
+            getJustOnePitestTaskOrFail().overriddenTargetTests = ["com.example.a.*", "com.example.b.*"]
         expect:
-        task.taskArgumentsMap()['targetTests'] == 'com.example.a.*,com.example.b.*'
+            task.taskArgumentMap()['targetTests'] == "com.example.a.*,com.example.b.*"
     }
 
 }

--- a/src/test/groovy/info/solidsoft/gradle/pitest/PitestTaskConfigurationSpec.groovy
+++ b/src/test/groovy/info/solidsoft/gradle/pitest/PitestTaskConfigurationSpec.groovy
@@ -15,11 +15,13 @@
  */
 package info.solidsoft.gradle.pitest
 
+import groovy.transform.CompileDynamic
 import spock.lang.Issue
 
+@CompileDynamic
 class PitestTaskConfigurationSpec extends BasicProjectBuilderSpec implements WithPitestTaskInitialization {
 
-    //public to be used also in functional tests
+    @SuppressWarnings('JUnitPublicField') //public to be used also in functional tests
     public static final List<String> PIT_PARAMETERS_NAMES_NOT_SET_BY_DEFAULT = ['classPathFile',
                                                                                 'features',
                                                                                 'excludedTestClasses',
@@ -28,7 +30,7 @@ class PitestTaskConfigurationSpec extends BasicProjectBuilderSpec implements Wit
                                                                                 'threads',
                                                                                 'mutateStaticInits',
                                                                                 'includeJarFiles',
-                                                                                "mutators",
+                                                                                'mutators',
                                                                                 'excludedMethods',
                                                                                 'excludedClasses',
                                                                                 'excludedTestClasses',
@@ -56,158 +58,174 @@ class PitestTaskConfigurationSpec extends BasicProjectBuilderSpec implements Wit
                                                                                 'features',
                                                                                 'historyInputLocation',
                                                                                 'historyOutputLocation',
-                                                                                'pluginConfiguration'
+                                                                                'pluginConfiguration',
     ]
 
-    def "should pass additional classpath to PIT using classPathFile parameter instead of classPath if configured"() {
+    void "should pass additional classpath to PIT using classPathFile parameter instead of classPath if configured"() {
         given:
-            project.pitest.useClasspathFile = true
+        project.pitest.useClasspathFile = true
+
         and:
-            new File(project.buildDir.absolutePath).mkdir() //in ProjectBuilder "build" directory is not created by default
+        new File(project.buildDir.absolutePath).mkdir() //in ProjectBuilder "build" directory is not created by default
+
         expect:
-            task.createTaskArgumentMap()['classPathFile'] == new File(project.buildDir, "pitClasspath").absolutePath
-            !task.createTaskArgumentMap()['classPath']
+        task.taskArgumentsMap()['classPathFile'] == new File(project.buildDir, 'pitClasspath').absolutePath
+        !task.taskArgumentsMap()['classPath']
     }
 
-    def "should pass features configuration to PIT"() {
+    void "should pass features configuration to PIT"() {
         given:
-            project.pitest.features = ["-FOO", "+BAR(a[1] a[2])"]
+        project.pitest.features = ['-FOO', '+BAR(a[1] a[2])']
+
         expect:
-            task.createTaskArgumentMap()['features'] == "-FOO,+BAR(a[1] a[2])"
+        task.taskArgumentsMap()['features'] == '-FOO,+BAR(a[1] a[2])'
     }
 
-    def "should pass additional features alone if features not set in configuration"() {
+    void "should pass additional features alone if features not set in configuration"() {
         given:
-            getJustOnePitestTaskOrFail().additionalFeatures = ['+XYZ', '-ABC']
+        getJustOnePitestTaskOrFail().additionalFeatures = ['+XYZ', '-ABC']
+
         expect:
-            task.createTaskArgumentMap()['features'] == "+XYZ,-ABC"
+        task.taskArgumentsMap()['features'] == '+XYZ,-ABC'
     }
 
-    def "should add additional features to those defined in configuration"() {
+    void "should add additional features to those defined in configuration"() {
         given:
-            project.pitest.features = ["-FOO", "+BAR"]
-            getJustOnePitestTaskOrFail().additionalFeatures = ['+XYZ', '-ABC']
+        project.pitest.features = ['-FOO', '+BAR']
+        getJustOnePitestTaskOrFail().additionalFeatures = ['+XYZ', '-ABC']
+
         expect:
-            task.createTaskArgumentMap()['features'] == "-FOO,+BAR,+XYZ,-ABC"
+        task.taskArgumentsMap()['features'] == '-FOO,+BAR,+XYZ,-ABC'
     }
 
-    def "should not pass features configuration to PIT if not set in configuration or via option"() {
+    void "should not pass features configuration to PIT if not set in configuration or via option"() {
         //Intentional duplication with generic parametrized tests to emphasis requirement
         expect:
-            task.createTaskArgumentMap()['featues'] == null
+        task.taskArgumentsMap()['featues'] == null
     }
 
-    def "should not pass to PIT parameter '#paramName' by default if not set explicitly"() {
+    void "should not pass to PIT parameter '#paramName' by default if not set explicitly"() {
         expect:
-            !task.createTaskArgumentMap().containsKey(paramName)
+        !task.taskArgumentsMap().containsKey(paramName)
+
         where:
-            //It would be best to have it generated automatically based. However, mapping between task parameters and map passed to PIT is not 1-to-1
-            paramName << PIT_PARAMETERS_NAMES_NOT_SET_BY_DEFAULT
+        //It would be best to have it generated automatically based. However, mapping between task parameters and map passed to PIT is not 1-to-1
+        paramName << PIT_PARAMETERS_NAMES_NOT_SET_BY_DEFAULT
     }
 
     //TODO: Run PIT with those values to detect removed properties and typos
-    def "should pass plugin configuration (#configParamName) from Gradle to PIT"() {
+    void "should pass plugin configuration (#configParamName) from Gradle to PIT"() {
         given:
-            project.pitest."${configParamName}" = gradleConfigValue
+        project.pitest."${configParamName}" = gradleConfigValue
+
         expect:
-            task.createTaskArgumentMap()[configParamName] == expectedPitConfigValue
-            // TODO: Move timeoutConst to separate test
+        task.taskArgumentsMap()[configParamName] == expectedPitConfigValue
+        // TODO: Move timeoutConst to separate test
+
         where:
-            //pitConfigParamName value taken from gradleConfigParamName if set to null
-            configParamName          | gradleConfigValue                            || expectedPitConfigValue
-            "testPlugin"             | "testng"                                     || "testng"
-            "reportDir"              | new File("//tmp//foo")                       || new File("//tmp//foo").path    //due to issues on Windows
-            "targetClasses"          | ["a", "b"]                                   || "a,b"
-            "targetTests"            | ["t1", "t2"]                                 || "t1,t2"
-            "dependencyDistance"     | 42                                           || "42"
-            "threads"                | 42                                           || "42"
-            "mutateStaticInits"      | true                                         || "true" //???
-            "includeJarFiles"        | false                                        || "false"
-            "mutators"               | ["MUTATOR_X", "MUTATOR_Y"]                   || "MUTATOR_X,MUTATOR_Y"
-            "excludedMethods"        | ["methodX", "methodY"]                       || "methodX,methodY"
-            "excludedClasses"        | ["classX", "foo.classY"]                     || "classX,foo.classY"
-            "excludedTestClasses"    | ["classX", "foo.classY"]                     || "classX,foo.classY"
-            "avoidCallsTo"           | ["callX", "foo.callY"]                       || "callX,foo.callY"
-            "verbose"                | true                                         || "true"
-            "timeoutFactor"          | 1.25                                         || "1.25"
-            "maxMutationsPerClass"   | 25                                           || "25"
-            "jvmArgs"                | ["-Xmx250m", "-Xms100m"]                     || "-Xmx250m,-Xms100m"
-            "outputFormats"          | ["HTML", "CSV"]                              || "HTML,CSV"
-            "failWhenNoMutations"    | false                                        || "false"
-            "skipFailingTests"       | true                                         || "true"
-            "includedGroups"         | ["Group1", "Group2"]                         || "Group1,Group2"
-            "excludedGroups"         | ["Group1", "Group2"]                         || "Group1,Group2"
-            "includedTestMethods"    | ["method1", "method2"]                       || "method1,method2"
-            "detectInlinedCode"      | true                                         || "true"
-            "timestampedReports"     | true                                         || "true"
-            "mutationThreshold"      | 90                                           || "90"
-            "coverageThreshold"      | 95                                           || "95"
-            "mutationEngine"         | "gregor2"                                    || "gregor2"
-            //sourceSet x2
-            "exportLineCoverage"     | true                                         || "true"
-            "jvmPath"                | new File("//opt//jvm15//")                   || new File("//opt//jvm15//").path
-            //mainProcessJvmArgs?
+        //pitConfigParamName value taken from gradleConfigParamName if set to null
+        configParamName          | gradleConfigValue                            | expectedPitConfigValue
+        'testPlugin'             | 'testng'                                     | 'testng'
+        'reportDir'              | new File('//tmp//foo')                       | new File('//tmp//foo').path    //due to issues on Windows
+        'targetClasses'          | ['a', 'b']                                   | 'a,b'
+        'targetTests'            | ['t1', 't2']                                 | 't1,t2'
+        'dependencyDistance'     | 42                                           | '42'
+        'threads'                | 42                                           | '42'
+        'mutateStaticInits'      | true                                         | 'true' //??
+        'includeJarFiles'        | false                                        | 'false'
+        'mutators'               | ['MUTATOR_X', 'MUTATOR_Y']                   | 'MUTATOR_X,MUTATOR_Y'
+        'excludedMethods'        | ['methodX', 'methodY']                       | 'methodX,methodY'
+        'excludedClasses'        | ['classX', 'foo.classY']                     | 'classX,foo.classY'
+        'excludedTestClasses'    | ['classX', 'foo.classY']                     | 'classX,foo.classY'
+        'avoidCallsTo'           | ['callX', 'foo.callY']                       | 'callX,foo.callY'
+        'verbose'                | true                                         | 'true'
+        'timeoutFactor'          | 1.25                                         | '1.25'
+        'maxMutationsPerClass'   | 25                                           | '25'
+        'jvmArgs'                | ['-Xmx250m', '-Xms100m']                     | '-Xmx250m,-Xms100m'
+        'outputFormats'          | ['HTML', 'CSV']                              | 'HTML,CSV'
+        'failWhenNoMutations'    | false                                        | 'false'
+        'skipFailingTests'       | true                                         | 'true'
+        'includedGroups'         | ['Group1', 'Group2']                         | 'Group1,Group2'
+        'excludedGroups'         | ['Group1', 'Group2']                         | 'Group1,Group2'
+        'includedTestMethods'    | ['method1', 'method2']                       | 'method1,method2'
+        'detectInlinedCode'      | true                                         | 'true'
+        'timestampedReports'     | true                                         | 'true'
+        'mutationThreshold'      | 90                                           | '90'
+        'coverageThreshold'      | 95                                           | '95'
+        'mutationEngine'         | 'gregor2'                                    | 'gregor2'
+        //sourceSet x2
+        'exportLineCoverage'     | true                                         | 'true'
+        'jvmPath'                | new File('//opt//jvm15//')                   | new File('//opt//jvm15//').path
+        //mainProcessJvmArgs?
 //            "pluginConfiguration"    | ["plugin1.key1": "v1", "plugin1.key2": "v2"] || "?"   //Tested separately
-            "maxSurviving"           | 20                                           || "20"
-            "useClasspathJar"        | true                                         || "true"
+        'maxSurviving'           | 20                                           | '20'
+        'useClasspathJar'        | true                                         | 'true'
 //            "useClasspathFile"       | true                                         || "false"    //TODO
-            "features"               | ["-FOO", "+BAR(a[1] a[2])"]                  || "-FOO,+BAR(a[1] a[2])"
+        'features'               | ['-FOO', '+BAR(a[1] a[2])']                  | '-FOO,+BAR(a[1] a[2])'
 //            "fileExtensionsToFilter" | ["zip", "xxx"]                               || "*.zip,*.xxx"  //not passed to PIT
-            "historyInputLocation"   | new File("//tmp//hi")                        || new File("//tmp//hi").path
-            "historyOutputLocation"  | new File("//tmp//ho")                        || new File("//tmp//ho").path
+        'historyInputLocation'   | new File('//tmp//hi')                        | new File('//tmp//hi').path
+        'historyOutputLocation'  | new File('//tmp//ho')                        | new File('//tmp//ho').path
     }
 
-    def "should pass plugin configuration (#gradleConfigParamName) from Gradle to PIT (overridden name)"() {
+    void "should pass plugin configuration (#gradleConfigParamName) from Gradle to PIT (overridden name)"() {
         given:
-            project.pitest."${gradleConfigParamName}" = gradleConfigValue
+        project.pitest."${gradleConfigParamName}" = gradleConfigValue
+
         expect:
-            task.createTaskArgumentMap()[pitConfigParamName ?: gradleConfigParamName] == expectedPitConfigValue
+        task.taskArgumentsMap()[pitConfigParamName ?: gradleConfigParamName] == expectedPitConfigValue
+
         where:
-            //pitConfigParamName value taken from gradleConfigParamName if set to null
-            gradleConfigParamName  | gradleConfigValue | pitConfigParamName || expectedPitConfigValue
-            "timeoutConstInMillis" | 100               | "timeoutConst"     || "100"
+        //pitConfigParamName value taken from gradleConfigParamName if set to null
+        gradleConfigParamName  | gradleConfigValue | pitConfigParamName | expectedPitConfigValue
+        'timeoutConstInMillis' | 100               | 'timeoutConst'     | '100'
 //            "useClasspathFile" | true               | "classPathFile"     || "?"    //tested separately
     }
 
-    def "should pass plugin configuration (mutableCodePaths) from Gradle to PIT"() {
+    void "should pass plugin configuration (mutableCodePaths) from Gradle to PIT"() {
         given:
-            project.pitest.additionalMutableCodePaths = [new File("//tmp//p1"), new File("//tmp//p2")]
+        project.pitest.additionalMutableCodePaths = [new File('//tmp//p1'), new File('//tmp//p2')]
+
         expect:
-            task.createTaskArgumentMap()["mutableCodePaths"].contains("${new File("//tmp//p1").path},${new File("//tmp//p2").path}")
+        task.taskArgumentsMap()['mutableCodePaths'].contains("${new File('//tmp//p1').path},${new File('//tmp//p2').path}")
     }
 
-    @Issue("https://github.com/szpak/gradle-pitest-plugin/issues/144")
-    def "should set targetTests to targetClasses by default if not defined in configuration"() {
+    @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/144')
+    void "should set targetTests to targetClasses by default if not defined in configuration"() {
         when:
-            project.pitest.targetClasses = ["myClasses.*"]
+        project.pitest.targetClasses = ['myClasses.*']
+
         then:
-            task.createTaskArgumentMap()['targetTests'] == "myClasses.*"
+        task.taskArgumentsMap()['targetTests'] == 'myClasses.*'
     }
 
-    @Issue("https://github.com/szpak/gradle-pitest-plugin/issues/144")
-    def "should set targetTests to configuration defined value"() {
+    @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/144')
+    void "should set targetTests to configuration defined value"() {
         when:
-            project.pitest.targetClasses = ["myClasses.*"]
-            project.pitest.targetTests = ["myClasses.tests.*"]
+        project.pitest.targetClasses = ['myClasses.*']
+        project.pitest.targetTests = ['myClasses.tests.*']
+
         then:
-            task.createTaskArgumentMap()['targetTests'] == "myClasses.tests.*"
+        task.taskArgumentsMap()['targetTests'] == 'myClasses.tests.*'
     }
 
-    @Issue("https://github.com/szpak/gradle-pitest-plugin/issues/143")
-    def "should override explicitly defined in configuration targetTests from command line"() {
+    @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/143')
+    void "should override explicitly defined in configuration targetTests from command line"() {
         given:
-            project.pitest.targetTests = ["com.foobar.*"]
-            getJustOnePitestTaskOrFail().overriddenTargetTests = ["com.example.a.*", "com.example.b.*"]
+        project.pitest.targetTests = ['com.foobar.*']
+        getJustOnePitestTaskOrFail().overriddenTargetTests = ['com.example.a.*', 'com.example.b.*']
+
         expect:
-            task.createTaskArgumentMap()['targetTests'] == "com.example.a.*,com.example.b.*"
+        task.taskArgumentsMap()['targetTests'] == 'com.example.a.*,com.example.b.*'
     }
 
-    @Issue("https://github.com/szpak/gradle-pitest-plugin/issues/143")
-    def "should override targetTests inferred from targetClasses from command line"() {
+    @Issue('https://github.com/szpak/gradle-pitest-plugin/issues/143')
+    void "should override targetTests inferred from targetClasses from command line"() {
         given:
-            project.pitest.targetClasses = ["com.foobar.*"]
-            getJustOnePitestTaskOrFail().overriddenTargetTests = ["com.example.a.*", "com.example.b.*"]
+        project.pitest.targetClasses = ['com.foobar.*']
+        getJustOnePitestTaskOrFail().overriddenTargetTests = ['com.example.a.*', 'com.example.b.*']
+
         expect:
-            task.createTaskArgumentMap()['targetTests'] == "com.example.a.*,com.example.b.*"
+        task.taskArgumentsMap()['targetTests'] == 'com.example.a.*,com.example.b.*'
     }
+
 }

--- a/src/test/groovy/info/solidsoft/gradle/pitest/PitestTaskIncrementalAnalysisTest.groovy
+++ b/src/test/groovy/info/solidsoft/gradle/pitest/PitestTaskIncrementalAnalysisTest.groovy
@@ -18,75 +18,65 @@ package info.solidsoft.gradle.pitest
 import groovy.transform.CompileDynamic
 
 @CompileDynamic
-class  PitestTaskIncrementalAnalysisTest extends BasicProjectBuilderSpec implements WithPitestTaskInitialization {
+class PitestTaskIncrementalAnalysisTest extends BasicProjectBuilderSpec implements WithPitestTaskInitialization {
 
     void "default analysis mode disabled by default"() {
         when:
-        Map<String, String> createdMap = task.taskArgumentsMap()
-
+            Map<String, String> createdMap = task.taskArgumentMap()
         then:
-        createdMap.get('enableDefaultIncrementalAnalysis') == null
+            createdMap.get("enableDefaultIncrementalAnalysis") == null
     }
 
     void "files for history location not set by default"() {
         when:
-        Map<String, String> createdMap = task.taskArgumentsMap()
-
+            Map<String, String> createdMap = task.taskArgumentMap()
         then:
-        createdMap.get('historyInputLocation') == null
-        createdMap.get('historyOutputLocation') == null
+            createdMap.get('historyInputLocation') == null
+            createdMap.get('historyOutputLocation') == null
     }
 
     void "set default files for history location in default incremental analysis mode ('#propertyName')"() {
         given:
-        project.pitest."$propertyName" = true
-
+            project.pitest."$propertyName" = true
         and:
-        String pitHistoryDefaultFile = new File(project.buildDir, PitestPlugin.PIT_HISTORY_DEFAULT_FILE_NAME).path
-
+            String pitHistoryDefaultFile = new File(project.buildDir, PitestPlugin.PIT_HISTORY_DEFAULT_FILE_NAME).path
         when:
-        Map<String, String> createdMap = task.taskArgumentsMap()
-
+            Map<String, String> createdMap = task.taskArgumentMap()
         then:
-        createdMap.get('historyInputLocation') == pitHistoryDefaultFile
-        createdMap.get('historyOutputLocation') == pitHistoryDefaultFile
-
+            createdMap.get('historyInputLocation') == pitHistoryDefaultFile
+            createdMap.get('historyOutputLocation') == pitHistoryDefaultFile
         where:
-        propertyName << ['enableDefaultIncrementalAnalysis', 'withHistory']
+            propertyName << ['enableDefaultIncrementalAnalysis', 'withHistory']
     }
 
     void "override files for history location when set explicit in configuration also default incremental analysis mode"() {
         given:
-        project.pitest  {
-            enableDefaultIncrementalAnalysis = true
-            historyInputLocation = new File('input')
-            historyOutputLocation = new File('output')
-        }
-
+            project.pitest  {
+                enableDefaultIncrementalAnalysis = true
+                historyInputLocation = new File('input')
+                historyOutputLocation = new File('output')
+            }
         when:
-        Map<String, String> createdMap = task.taskArgumentsMap()
-
+            Map<String, String> createdMap = task.taskArgumentMap()
         then:
-        createdMap.get('historyInputLocation') == task.historyInputLocation.asFile.get().path
-        createdMap.get('historyOutputLocation') == task.historyOutputLocation.asFile.get().path
+            createdMap.get('historyInputLocation') == task.historyInputLocation.asFile.get().path
+            createdMap.get('historyOutputLocation') == task.historyOutputLocation.asFile.get().path
     }
 
     void "given in configuration files for history location are used also not in default incremental analysis mode"() {
         given:
-        project.pitest {
-            enableDefaultIncrementalAnalysis = false
-            historyInputLocation = new File('input')
-            historyOutputLocation = new File('output')
-        }
-
+            project.pitest {
+                enableDefaultIncrementalAnalysis = false
+                historyInputLocation = new File('input')
+                historyOutputLocation = new File('output')
+            }
         and:
-        task = getJustOnePitestTaskOrFail()
-
+            task = getJustOnePitestTaskOrFail()
         when:
-        Map<String, String> createdMap = task.taskArgumentsMap()
+            Map<String, String> createdMap = task.taskArgumentMap()
         then:
-        createdMap.get('historyInputLocation') == task.historyInputLocation.asFile.get().path
-        createdMap.get('historyOutputLocation') == task.historyOutputLocation.asFile.get().path
+            createdMap.get('historyInputLocation') == task.historyInputLocation.asFile.get().path
+            createdMap.get('historyOutputLocation') == task.historyOutputLocation.asFile.get().path
     }
 
 }

--- a/src/test/groovy/info/solidsoft/gradle/pitest/PitestTaskIncrementalAnalysisTest.groovy
+++ b/src/test/groovy/info/solidsoft/gradle/pitest/PitestTaskIncrementalAnalysisTest.groovy
@@ -15,64 +15,78 @@
  */
 package info.solidsoft.gradle.pitest
 
-class PitestTaskIncrementalAnalysisTest extends BasicProjectBuilderSpec implements WithPitestTaskInitialization {
+import groovy.transform.CompileDynamic
 
-    def "default analysis mode disabled by default"() {
+@CompileDynamic
+class  PitestTaskIncrementalAnalysisTest extends BasicProjectBuilderSpec implements WithPitestTaskInitialization {
+
+    void "default analysis mode disabled by default"() {
         when:
-            Map<String, String> createdMap = task.createTaskArgumentMap()
+        Map<String, String> createdMap = task.taskArgumentsMap()
+
         then:
-            createdMap.get("enableDefaultIncrementalAnalysis") == null
+        createdMap.get('enableDefaultIncrementalAnalysis') == null
     }
 
-    def "files for history location not set by default"() {
+    void "files for history location not set by default"() {
         when:
-            Map<String, String> createdMap = task.createTaskArgumentMap()
+        Map<String, String> createdMap = task.taskArgumentsMap()
+
         then:
-            createdMap.get('historyInputLocation') == null
-            createdMap.get('historyOutputLocation') == null
+        createdMap.get('historyInputLocation') == null
+        createdMap.get('historyOutputLocation') == null
     }
 
-    def "set default files for history location in default incremental analysis mode ('#propertyName')"() {
+    void "set default files for history location in default incremental analysis mode ('#propertyName')"() {
         given:
-            project.pitest."$propertyName" = true
+        project.pitest."$propertyName" = true
+
         and:
-            String pitHistoryDefaultFile = new File(project.buildDir, PitestPlugin.PIT_HISTORY_DEFAULT_FILE_NAME).path
+        String pitHistoryDefaultFile = new File(project.buildDir, PitestPlugin.PIT_HISTORY_DEFAULT_FILE_NAME).path
+
         when:
-            Map<String, String> createdMap = task.createTaskArgumentMap()
+        Map<String, String> createdMap = task.taskArgumentsMap()
+
         then:
-            createdMap.get('historyInputLocation') == pitHistoryDefaultFile
-            createdMap.get('historyOutputLocation') == pitHistoryDefaultFile
+        createdMap.get('historyInputLocation') == pitHistoryDefaultFile
+        createdMap.get('historyOutputLocation') == pitHistoryDefaultFile
+
         where:
-            propertyName << ['enableDefaultIncrementalAnalysis', 'withHistory']
+        propertyName << ['enableDefaultIncrementalAnalysis', 'withHistory']
     }
 
-    def "override files for history location when set explicit in configuration also default incremental analysis mode"() {
+    void "override files for history location when set explicit in configuration also default incremental analysis mode"() {
         given:
-            project.pitest  {
-                enableDefaultIncrementalAnalysis = true
-                historyInputLocation = new File('input')
-                historyOutputLocation = new File('output')
-            }
+        project.pitest  {
+            enableDefaultIncrementalAnalysis = true
+            historyInputLocation = new File('input')
+            historyOutputLocation = new File('output')
+        }
+
         when:
-            Map<String, String> createdMap = task.createTaskArgumentMap()
+        Map<String, String> createdMap = task.taskArgumentsMap()
+
         then:
-            createdMap.get('historyInputLocation') == task.historyInputLocation.asFile.get().path
-            createdMap.get('historyOutputLocation') == task.historyOutputLocation.asFile.get().path
+        createdMap.get('historyInputLocation') == task.historyInputLocation.asFile.get().path
+        createdMap.get('historyOutputLocation') == task.historyOutputLocation.asFile.get().path
     }
 
-    def "given in configuration files for history location are used also not in default incremental analysis mode"() {
+    void "given in configuration files for history location are used also not in default incremental analysis mode"() {
         given:
-            project.pitest {
-                enableDefaultIncrementalAnalysis = false
-                historyInputLocation = new File('input')
-                historyOutputLocation = new File('output')
-            }
+        project.pitest {
+            enableDefaultIncrementalAnalysis = false
+            historyInputLocation = new File('input')
+            historyOutputLocation = new File('output')
+        }
+
         and:
-            task = getJustOnePitestTaskOrFail()
+        task = getJustOnePitestTaskOrFail()
+
         when:
-            Map<String, String> createdMap = task.createTaskArgumentMap()
+        Map<String, String> createdMap = task.taskArgumentsMap()
         then:
-            createdMap.get('historyInputLocation') == task.historyInputLocation.asFile.get().path
-            createdMap.get('historyOutputLocation') == task.historyOutputLocation.asFile.get().path
+        createdMap.get('historyInputLocation') == task.historyInputLocation.asFile.get().path
+        createdMap.get('historyOutputLocation') == task.historyOutputLocation.asFile.get().path
     }
+
 }

--- a/src/test/groovy/info/solidsoft/gradle/pitest/PitestTaskPluginConfigurationTest.groovy
+++ b/src/test/groovy/info/solidsoft/gradle/pitest/PitestTaskPluginConfigurationTest.groovy
@@ -22,24 +22,20 @@ class PitestTaskPluginConfigurationTest extends BasicProjectBuilderSpec implemen
 
     void "should not create pluginConfiguration command line argument when no parameters"() {
         given:
-        project.pitest.pluginConfiguration = null
-
+            project.pitest.pluginConfiguration = null
         when:
-        List<String> multiValueArgList = task.multiValueArgsAsList()
-
+            List<String> multiValueArgList = task.multiValueArgsAsList()
         then:
-        multiValueArgList['pluginConfiguration'] == []
+            multiValueArgList['pluginConfiguration'] == []
     }
 
     void "should split parameters into separate pluginConfiguration arguments"() {
         given:
-        project.pitest.pluginConfiguration = ['plugin1.foo':'one', 'plugin1.bar':'2']
-
+            project.pitest.pluginConfiguration = ["plugin1.foo":"one", "plugin1.bar":"2"]
         when:
-        List<String> multiValueArgList = task.multiValueArgsAsList()
-
+            List<String> multiValueArgList = task.multiValueArgsAsList()
         then:
-        multiValueArgList == ['--pluginConfiguration=plugin1.foo=one', '--pluginConfiguration=plugin1.bar=2']
+            multiValueArgList == ['--pluginConfiguration=plugin1.foo=one', '--pluginConfiguration=plugin1.bar=2']
     }
 
 }

--- a/src/test/groovy/info/solidsoft/gradle/pitest/PitestTaskPluginConfigurationTest.groovy
+++ b/src/test/groovy/info/solidsoft/gradle/pitest/PitestTaskPluginConfigurationTest.groovy
@@ -15,23 +15,31 @@
  */
 package info.solidsoft.gradle.pitest
 
+import groovy.transform.CompileDynamic
+
+@CompileDynamic
 class PitestTaskPluginConfigurationTest extends BasicProjectBuilderSpec implements WithPitestTaskInitialization {
 
-    def "should not create pluginConfiguration command line argument when no parameters"() {
+    void "should not create pluginConfiguration command line argument when no parameters"() {
         given:
-            project.pitest.pluginConfiguration = null
+        project.pitest.pluginConfiguration = null
+
         when:
-            List<String> multiValueArgList = task.createMultiValueArgsAsList()
+        List<String> multiValueArgList = task.multiValueArgsAsList()
+
         then:
-            multiValueArgList['pluginConfiguration'] == []
+        multiValueArgList['pluginConfiguration'] == []
     }
 
-    def "should split parameters into separate pluginConfiguration arguments"() {
+    void "should split parameters into separate pluginConfiguration arguments"() {
         given:
-            project.pitest.pluginConfiguration = ["plugin1.foo": "one", "plugin1.bar": "2"]
+        project.pitest.pluginConfiguration = ['plugin1.foo':'one', 'plugin1.bar':'2']
+
         when:
-            List<String> multiValueArgList = task.createMultiValueArgsAsList()
+        List<String> multiValueArgList = task.multiValueArgsAsList()
+
         then:
-            multiValueArgList == ['--pluginConfiguration=plugin1.foo=one', '--pluginConfiguration=plugin1.bar=2']
+        multiValueArgList == ['--pluginConfiguration=plugin1.foo=one', '--pluginConfiguration=plugin1.bar=2']
     }
+
 }

--- a/src/test/groovy/info/solidsoft/gradle/pitest/WithPitestTaskInitialization.groovy
+++ b/src/test/groovy/info/solidsoft/gradle/pitest/WithPitestTaskInitialization.groovy
@@ -1,14 +1,16 @@
 package info.solidsoft.gradle.pitest
 
+import groovy.transform.CompileDynamic
 import groovy.transform.SelfType
 
 @SelfType(BasicProjectBuilderSpec)
-//@CompileStatic  //Fails with: Error:(13, 16) Groovyc: [Static type checking] - Non static method info.solidsoft.gradle.pitest.BasicProjectBuilderSpec#getJustOnePitestTaskOrFail cannot be called from static context
+@CompileDynamic
 trait WithPitestTaskInitialization {
 
     PitestTask task
 
-    def setup() {
+    void setup() {
         task = getJustOnePitestTaskOrFail()
     }
+
 }

--- a/src/test/groovy/info/solidsoft/gradle/pitest/WithPitestTaskInitialization.groovy
+++ b/src/test/groovy/info/solidsoft/gradle/pitest/WithPitestTaskInitialization.groovy
@@ -4,6 +4,7 @@ import groovy.transform.CompileDynamic
 import groovy.transform.SelfType
 
 @SelfType(BasicProjectBuilderSpec)
+//@CompileStatic  //Fails with: Error:(13, 16) Groovyc: [Static type checking] - Non static method info.solidsoft.gradle.pitest.BasicProjectBuilderSpec#getJustOnePitestTaskOrFail cannot be called from static context
 @CompileDynamic
 trait WithPitestTaskInitialization {
 


### PR DESCRIPTION
Closes #78 

There are 6 CodeNarc rulesets that weren't applied:
1. comments - for future consideration
2. enhanced - need to provide project's classpath to CodeNarc so it can perform more detailed analysis, so left it out for now
2. grails - not used by this project
1. jdbc - not used by this project
1. security - seems more relevant for daemons, though removing direct usage of java.io.File (see https://github.com/szpak/gradle-pitest-plugin/pull/183#issuecomment-593074829) should allow this ruleset to be enabled without any other changes
1. size - would require too much refactoring to apply in this PR

A few specific rules have been excluded as well - DuplicateStringLiteral and LineLength would be easy to fix, I just didn't have the time today. JUnitPublicNonTestMethod and MethodName caused problems in the test sourcesets, and UnnecessaryGetter looked like it was warning on usage of the Gradle property API, and making the suggested changes would have caused compilation failures.

Just a warning that I've had minimal exposure to Groovy outside of Gradle (and its sources) and have never used CodeNarc before, so this will require a careful review. I'm happy to revert any of these changes or disable any [rules ](http://codenarc.github.io/CodeNarc/codenarc-rule-index.html)that don't fit with the project's code style.