### PR TITLE
Support java-test-fixtures plugin

### DIFF
--- a/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/Junit5FunctionalSpec.groovy
+++ b/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/Junit5FunctionalSpec.groovy
@@ -11,8 +11,10 @@ class Junit5FunctionalSpec extends AbstractPitestFunctionalSpec {
         given:
             copyResources("testProjects/junit5kotlin", "")
         when:
-            ExecutionResult result = runTasksSuccessfully('pitest')
+            ExecutionResult result = runTasks('pitest')
         then:
+            !result.standardError.contains("Build failed with an exception")
+            !result.failure
             result.wasExecuted('pitest')
             result.standardOutput.contains('Generated 2 mutations Killed 2 (100%)')
     }
@@ -21,8 +23,10 @@ class Junit5FunctionalSpec extends AbstractPitestFunctionalSpec {
         given:
             copyResources("testProjects/junit5kotlin", "")
         when:
-            ExecutionResult result = runTasksSuccessfully('pitest', '-b', 'build.gradle.kts')
+            ExecutionResult result = runTasks('pitest', '-b', 'build.gradle.kts')
         then:
+            !result.standardError.contains("Build failed with an exception")
+            !result.failure
             result.wasExecuted('pitest')
             result.standardOutput.contains('Generated 2 mutations Killed 2 (100%)')
     }
@@ -32,8 +36,10 @@ class Junit5FunctionalSpec extends AbstractPitestFunctionalSpec {
         given:
             copyResources("testProjects/junit5simple", "")
         when:
-            ExecutionResult result = runTasksSuccessfully('pitest')
+            ExecutionResult result = runTasks('pitest')
         then:
+            !result.standardError.contains("Build failed with an exception")
+            !result.failure
             result.wasExecuted('pitest')
         and:
             result.standardOutput.contains('--testPlugin=junit5')

--- a/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/TestFixturesFunctionalSpec.groovy
+++ b/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/TestFixturesFunctionalSpec.groovy
@@ -1,0 +1,21 @@
+package info.solidsoft.gradle.pitest.functional
+
+import groovy.transform.CompileDynamic
+import nebula.test.functional.ExecutionResult
+
+@CompileDynamic
+class TestFixturesFunctionalSpec extends AbstractPitestFunctionalSpec {
+
+    void "should work with java-test-fixtures plugin"() {
+        given:
+            copyResources("testProjects/testFixtures", "")
+        when:
+            ExecutionResult result = runTasks('pitest')
+        then:
+            !result.standardError.contains("Build failed with an exception")
+            !result.failure
+            result.wasExecuted('pitest')
+            result.standardOutput.contains('Generated 1 mutations Killed 1 (100%)')
+    }
+
+}

--- a/src/funcTest/resources/testProjects/testFixtures/build.gradle
+++ b/src/funcTest/resources/testProjects/testFixtures/build.gradle
@@ -1,0 +1,24 @@
+apply plugin: 'java-library'
+apply plugin: 'java-test-fixtures'
+apply plugin: 'info.solidsoft.pitest'
+
+buildscript {
+    repositories {
+        mavenCentral()
+        mavenLocal()
+    }
+    dependencies {
+        //Local/current version of the plugin should be put on a classpath earlier to override that plugin version
+//        classpath 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.1.7-SNAPSHOT'
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+group = "pitest.test"
+
+dependencies {
+    testImplementation 'junit:junit:4.12'
+}

--- a/src/funcTest/resources/testProjects/testFixtures/settings.gradle
+++ b/src/funcTest/resources/testProjects/testFixtures/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'testFixtures'

--- a/src/funcTest/resources/testProjects/testFixtures/src/main/java/pitest/test/Library.java
+++ b/src/funcTest/resources/testProjects/testFixtures/src/main/java/pitest/test/Library.java
@@ -1,0 +1,7 @@
+package pitest.test;
+
+public class Library {
+    public boolean someLibraryMethod() {
+        return true;
+    }
+}

--- a/src/funcTest/resources/testProjects/testFixtures/src/test/java/pitest/test/LibraryTest.java
+++ b/src/funcTest/resources/testProjects/testFixtures/src/test/java/pitest/test/LibraryTest.java
@@ -1,0 +1,13 @@
+package pitest.test;
+
+import org.junit.Test;
+import pitest.test.Library;
+
+import static org.junit.Assert.*;
+
+public class LibraryTest {
+    @Test public void testSomeLibraryMethod() {
+        Library classUnderTest = new Library();
+        assertTrue("someLibraryMethod should return 'true'", classUnderTest.someLibraryMethod());
+    }
+}

--- a/src/test/groovy/info/solidsoft/gradle/pitest/PitestTaskConfigurationSpec.groovy
+++ b/src/test/groovy/info/solidsoft/gradle/pitest/PitestTaskConfigurationSpec.groovy
@@ -244,7 +244,11 @@ class PitestTaskConfigurationSpec extends BasicProjectBuilderSpec implements Wit
             project.sourceSets { intTest }
             project.pitest.testSourceSets = [project.sourceSets.intTest]
         expect:
-            task.taskArgumentMap()['classPath'] == assembleSourceSetsClasspathByNameAsStringSet("intTest").join(",")
+            task.taskArgumentMap()['classPath'] ==
+                (
+                    assembleSourceSetsClasspathByNameAsStringSet("intTest") +
+                    [new File(project.buildDir, "classes/java/main").absolutePath]
+                ).join(",")
     }
 
     private Set<String> assembleSourceSetsClasspathByNameAsStringSet(List<String> sourceSetNames) {
@@ -254,8 +258,8 @@ class PitestTaskConfigurationSpec extends BasicProjectBuilderSpec implements Wit
     }
 
     private Set<String> assembleSourceSetsClasspathByNameAsStringSet(String sourceSetName) {
-        return [new File(project.buildDir, "classes//java//${sourceSetName}"),
-                new File(project.buildDir, "resources//${sourceSetName}")
+        return [new File(project.buildDir, "classes/java/${sourceSetName}"),
+                new File(project.buildDir, "resources/${sourceSetName}")
         ]*.absolutePath
     }
 

--- a/src/test/groovy/info/solidsoft/gradle/pitest/PitestTaskConfigurationSpec.groovy
+++ b/src/test/groovy/info/solidsoft/gradle/pitest/PitestTaskConfigurationSpec.groovy
@@ -233,34 +233,37 @@ class PitestTaskConfigurationSpec extends BasicProjectBuilderSpec implements Wit
             sourceDirs == assembleMainSourceDirAsStringSet().join(",")
     }
 
-    private Set<String> assembleMainSourceDirAsStringSet() {
-        return ["resources", "java"].collect { String dirName ->
-            new File(project.projectDir, "src//main//${dirName}")
-        }*.absolutePath
-    }
-
     void "should consider testSourceSets in (additional) classpath"() {
         given:
             project.sourceSets { intTest }
             project.pitest.testSourceSets = [project.sourceSets.intTest]
         expect:
-            task.taskArgumentMap()['classPath'] ==
-                (
-                    assembleSourceSetsClasspathByNameAsStringSet("intTest") +
-                    [new File(project.buildDir, "classes/java/main").absolutePath]
-                ).join(",")
+            task.taskArgumentMap()['classPath'].split(",") as Set ==
+                [
+                    sourceSetBuiltJavaClasses("intTest"),
+                    sourceSetBuiltResources("intTest"),
+                    sourceSetBuiltJavaClasses("main")
+                ] as Set
     }
 
     private Set<String> assembleSourceSetsClasspathByNameAsStringSet(List<String> sourceSetNames) {
         return sourceSetNames.collectMany { String sourceSetName ->
-            assembleSourceSetsClasspathByNameAsStringSet(sourceSetName)
+            [sourceSetBuiltJavaClasses(sourceSetName), sourceSetBuiltResources(sourceSetName)]
         } as Set<String>
     }
 
-    private Set<String> assembleSourceSetsClasspathByNameAsStringSet(String sourceSetName) {
-        return [new File(project.buildDir, "classes/java/${sourceSetName}"),
-                new File(project.buildDir, "resources/${sourceSetName}")
-        ]*.absolutePath
+    private Set<String> assembleMainSourceDirAsStringSet() {
+        return ["resources", "java"].collect { String dirName ->
+            new File(project.projectDir, "src/main/${dirName}")
+        }*.absolutePath
+    }
+
+    private String sourceSetBuiltJavaClasses(String sourceSetName) {
+        return new File(project.buildDir, "classes/java/${sourceSetName}").absolutePath
+    }
+
+    private String sourceSetBuiltResources(String sourceSetName) {
+        return new File(project.buildDir, "resources/${sourceSetName}").absolutePath
     }
 
 }


### PR DESCRIPTION
Applying 'java-test-fixtures' plugin caused 'No mutations found' from Pitest.

The plugin changes test runtime classpath: tested code is included as a JAR instead of as a directory
(see gradle/gradle#11696). It seems that Pitest ignores correct directories being passed using --mutableCodePaths and insists on having those directories also passed in --classPath.

Also change functional tests: runTasksSuccessfully() fails the test without giving any context, so it should be avoided.

---

The project I work on uses java-test-fixtures plugin, so this issue blocks me from using Pitest.