### PR TITLE
Add required option for the report aggregation task

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ subprojects {
         // export mutations.xml and line coverage for aggregation
         outputFormats = ["XML"]
         exportLineCoverage = true
+        timestampedReports = false
         ...
     }
 }


### PR DESCRIPTION
Aggregation task search 'linecode.xml' in the path like '\build\reports\pitest\linecoverage.xml'.
So, 'timestampedReports' is enable by default, there is 'File does not exist' error because the path is like '\build\reports\pitest\*some_time*\linecoverage.xml'