### PR TITLE
Set main for JavaExec using mainClass property

### DIFF
--- a/src/main/groovy/info/solidsoft/gradle/pitest/PitestTask.groovy
+++ b/src/main/groovy/info/solidsoft/gradle/pitest/PitestTask.groovy
@@ -242,9 +242,7 @@ class PitestTask extends JavaExec {
     List<String> overriddenTargetTests  //should be Set<String> or SetProperty but it's not supported in Gradle as of 5.6.1
 
     PitestTask() {
-        //setting during execution doesn't work in 6.4+:
-        //The value for task ':pitest' property 'mainClass' is final and cannot be changed any further.
-        main = "org.pitest.mutationtest.commandline.MutationCoverageReport"
+        getMainClass().set("org.pitest.mutationtest.commandline.MutationCoverageReport")
 
         ObjectFactory of = project.objects
 


### PR DESCRIPTION
Setting `main` is deprecated in Gradle 7.X and will be removed in Gradle 8.0. This sets the main class using the `mainClass` property.