### PR TITLE
Added test to check exclusion of certain mutators

### DIFF
--- a/src/test/groovy/info/solidsoft/gradle/pitest/PitestTaskConfigurationSpec.groovy
+++ b/src/test/groovy/info/solidsoft/gradle/pitest/PitestTaskConfigurationSpec.groovy
@@ -134,7 +134,7 @@ class PitestTaskConfigurationSpec extends BasicProjectBuilderSpec implements Wit
             "targetTests"            | ["t1", "t2"]                                 || "t1,t2"
             "dependencyDistance"     | 42                                           || "42"
             "threads"                | 42                                           || "42"
-            "mutators"               | ["MUTATOR_X", "MUTATOR_Y"]                   || "MUTATOR_X,MUTATOR_Y"
+            "mutators"               | ["MUTATOR_X", "MUTATOR_Y", "-MUTATOR_Z"]     || "MUTATOR_X,MUTATOR_Y,-MUTATOR_Z"
             "excludedMethods"        | ["methodX", "methodY"]                       || "methodX,methodY"
             "excludedClasses"        | ["classX", "foo.classY"]                     || "classX,foo.classY"
             "excludedTestClasses"    | ["classX", "foo.classY"]                     || "classX,foo.classY"


### PR DESCRIPTION
With PIT version 1.7.3, exclusion of mutators is possible using "-UOI" syntax.

So added a test case in order to verify that such configuration does not cause any issue in plugin code and configuration is passed to plugin as per expectation.

https://github.com/hcoles/pitest/issues/954