### PR TITLE
Add pitest dependencies only during configuration resolution #302

### DIFF
--- a/src/test/groovy/info/solidsoft/gradle/pitest/PitestAggregatorPluginTest.groovy
+++ b/src/test/groovy/info/solidsoft/gradle/pitest/PitestAggregatorPluginTest.groovy
@@ -26,7 +26,7 @@ class PitestAggregatorPluginTest extends Specification {
         and:
             triggerEvaluateForAggregateTask()
         then:
-            project.configurations.named("pitestReport").get().dependencies.find { dep ->
+            project.configurations.named("pitestReport").get().incoming.dependencies.find { dep ->
                 dep.version == PitestPlugin.DEFAULT_PITEST_VERSION
             }
     }
@@ -42,7 +42,7 @@ class PitestAggregatorPluginTest extends Specification {
         and:
             triggerEvaluateForAggregateTask()
         then:
-            project.configurations.named(PitestAggregatorPlugin.PITEST_REPORT_AGGREGATE_CONFIGURATION_NAME).get().dependencies.find { dep ->
+            project.configurations.named(PitestAggregatorPlugin.PITEST_REPORT_AGGREGATE_CONFIGURATION_NAME).get().incoming.dependencies.find { dep ->
                 dep.version == testPitestVersion
             }
     }


### PR DESCRIPTION
Changes the adding of dependencies to the pitest configuration to use the [withDependencies](https://docs.gradle.org/current/javadoc/org/gradle/api/artifacts/Configuration.html#withDependencies-org.gradle.api.Action-) method, and moves the addition of dependencies to occur during plugin configuration instead of task configuration.

I ran into the same error reported by #302 when using the VSCode vscode-gradle extension (3.10.0+), and I believe that the issue is caused by the pitest configuration (probably all configurations) being resolved during the project configuration phase - before this plugins' tasks add their dependencies. The intent of my changes are to wrap this plugin's dependency additions in a configuration action that will be executed whenever the pitest configuration is resolved - whether by the pitest task or some other reason (vscode-gradle plugin or project-report).

Fixes the issue when using both the project-report plugin and the VSCode vscode-gradle extension.