### PR TITLE
docs: Include instructions to load 'java' or 'java-library' plugins as needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Add gradle-pitest-plugin to the `plugins` configuration in your `build.gradle` f
 
 ```groovy
 plugins {
+    id 'java' //or 'java-library' - depending on your needs
     id 'info.solidsoft.pitest' version '1.9.11'
 }
 ```
@@ -55,6 +56,7 @@ buildscript {
 Apply the plugin:
 
 ```groovy
+apply plugin: 'java' //or 'java-library' - depending on your needs
 apply plugin: 'info.solidsoft.pitest'
 ```
 


### PR DESCRIPTION
There are some cases when `pitest` is not visible as Gradle task, unless you explicitly apply the `java` or `java-library` plugin.
This PR include this instructions into README file

Issue Reference: https://github.com/szpak/gradle-pitest-plugin/issues/330