### PR TITLE
Ability to override `verbose` from command line

### DIFF
--- a/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/OverridePluginFunctionalSpec.groovy
+++ b/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/OverridePluginFunctionalSpec.groovy
@@ -80,4 +80,20 @@ class OverridePluginFunctionalSpec extends AbstractPitestFunctionalSpec {
             result.standardOutput.contains("--targetTests=$overriddenTargetTests")
     }
 
+    void "should allow to enable verbose output from command line"() {
+        given:
+            buildFile << """
+                ${getBasicGradlePitestConfig()}
+
+                pitest {
+                    failWhenNoMutations = false
+                    verbose = false
+                }
+            """.stripIndent()
+        when:
+            ExecutionResult result = runTasksSuccessfully('pitest', '--verbose')
+        then:
+            result.standardOutput.contains("--verbose=true")
+    }
+
 }

--- a/src/main/groovy/info/solidsoft/gradle/pitest/PitestTask.groovy
+++ b/src/main/groovy/info/solidsoft/gradle/pitest/PitestTask.groovy
@@ -249,6 +249,12 @@ class PitestTask extends JavaExec {
     @Optional
     List<String> overriddenTargetTests  //should be Set<String> or SetProperty but it's not supported in Gradle as of 5.6.1
 
+    @Incubating
+    @Option(option = "verbose", description = "Output verbose logging. Overrides 'verbose' defined in configuration")
+    @Input
+    @Optional
+    Boolean overriddenVerbose
+
     PitestTask() {
         getMainClass().set("org.pitest.mutationtest.commandline.MutationCoverageReport")
 
@@ -354,7 +360,7 @@ class PitestTask extends JavaExec {
         map['excludedClasses'] = optionalCollectionAsString(excludedClasses)
         map['excludedTestClasses'] = optionalCollectionAsString(excludedTestClasses)
         map['avoidCallsTo'] = optionalCollectionAsString(avoidCallsTo)
-        map['verbose'] = optionalPropertyAsString(verbose)
+        map['verbose'] = overriddenVerbose ? overriddenVerbose.toString() : optionalPropertyAsString(verbose)
         map['verbosity'] = optionalPropertyAsString(verbosity)
         map['timeoutFactor'] = optionalPropertyAsString(timeoutFactor)
         map['timeoutConst'] = optionalPropertyAsString(timeoutConstInMillis)


### PR DESCRIPTION
When analyzing configuration failures of Pitest it's often necessary to temporarily turn on verbose output. Changing the configuration in gradle files is possible but obviously has some drawbacks.

This change adds the ability to turn on verbose output from the command line via an optional parameter:

`./gradlew pitest --verbose`

Fixes #349