### PR TITLE
[#333] Fix Gradle configuration cache issues for 8.1 and up

### DIFF
--- a/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/Junit5FunctionalSpec.groovy
+++ b/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/Junit5FunctionalSpec.groovy
@@ -2,6 +2,7 @@ package info.solidsoft.gradle.pitest.functional
 
 import groovy.transform.CompileDynamic
 import nebula.test.functional.ExecutionResult
+import spock.lang.Ignore
 import spock.lang.Issue
 
 @CompileDynamic
@@ -83,6 +84,20 @@ class Junit5FunctionalSpec extends AbstractPitestFunctionalSpec {
         and:
             result.standardOutput.contains('Configuration cache entry stored')
             result2.standardOutput.contains('Reusing configuration cache.')
+    }
+
+    @Issue("https://github.com/szpak/gradle-pitest-plugin/issues/333")
+    @Ignore("This requires Gradle 8.1, and its Groovy is too modern for Spock 2.3-groovy-2.5, and Gradle 6.9.2 is too old for 2.3-groovy-3.0.")
+    void "should not reference project data at execution time"() {
+        given:
+            gradleVersion = "8.1"
+            copyResources("testProjects/junit5simple", "")
+        when:
+            ExecutionResult result = runTasks('pitest', '--configuration-cache', '--rerun-tasks')
+        then:
+            !result.standardError.contains('invocation of \'Task.project\' at execution time is unsupported.')
+            !result.failure
+            result.wasExecuted('pitest')
     }
 
 }

--- a/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/Junit5FunctionalSpec.groovy
+++ b/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/Junit5FunctionalSpec.groovy
@@ -1,8 +1,9 @@
 package info.solidsoft.gradle.pitest.functional
 
+import com.google.common.base.Predicates
 import groovy.transform.CompileDynamic
 import nebula.test.functional.ExecutionResult
-import spock.lang.Ignore
+import nebula.test.functional.GradleRunner
 import spock.lang.Issue
 
 @CompileDynamic
@@ -87,10 +88,11 @@ class Junit5FunctionalSpec extends AbstractPitestFunctionalSpec {
     }
 
     @Issue("https://github.com/szpak/gradle-pitest-plugin/issues/333")
-    @Ignore("This requires Gradle 8.1, and its Groovy is too modern for Spock 2.3-groovy-2.5, and Gradle 6.9.2 is too old for 2.3-groovy-3.0.")
-    void "should not reference project data at execution time"() {
+    void "should not reference project data at execution time (causing InvalidUserCodeException in Gradle 8.1+)"() {
         given:
             gradleVersion = "8.1"
+            classpathFilter = Predicates.and(GradleRunner.CLASSPATH_DEFAULT, PitestPluginGradleVersionFunctionalSpec.FILTER_SPOCK_JAR)
+        and:
             copyResources("testProjects/junit5simple", "")
         when:
             ExecutionResult result = runTasks('pitest', '--configuration-cache', '--rerun-tasks')

--- a/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/PitestPluginGradleVersionFunctionalSpec.groovy
+++ b/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/PitestPluginGradleVersionFunctionalSpec.groovy
@@ -3,6 +3,7 @@ package info.solidsoft.gradle.pitest.functional
 import com.google.common.base.Predicate
 import com.google.common.base.Predicates
 import groovy.transform.CompileDynamic
+import groovy.transform.PackageScope
 import groovy.util.logging.Slf4j
 import info.solidsoft.gradle.pitest.PitestPlugin
 import nebula.test.functional.ExecutionResult
@@ -94,7 +95,9 @@ class PitestPluginGradleVersionFunctionalSpec extends AbstractPitestFunctionalSp
     //To prevent failure when Spock for Groovy 2.5 is run with Groovy 3.0 delivered with Gradle 7+
     //Spock is not needed in this artificial project - just the test classpath leaks to Gradle instance started by Nebula
     private static final Pattern SPOCK_JAR_PATTERN = Pattern.compile(".*spock-core-2\\..*.jar")
-    private static final Predicate<URL> FILTER_SPOCK_JAR = { URL url ->
+    @SuppressWarnings('JUnitPublicProperty')
+    @PackageScope
+    static final Predicate<URL> FILTER_SPOCK_JAR = { URL url ->
         return !url.toExternalForm().matches(SPOCK_JAR_PATTERN)
     } as Predicate<URL>
 

--- a/src/main/groovy/info/solidsoft/gradle/pitest/PitestTask.groovy
+++ b/src/main/groovy/info/solidsoft/gradle/pitest/PitestTask.groovy
@@ -249,10 +249,14 @@ class PitestTask extends JavaExec {
     @Optional
     List<String> overriddenTargetTests  //should be Set<String> or SetProperty but it's not supported in Gradle as of 5.6.1
 
+    @Internal
+    File rootDir
+
     PitestTask() {
         getMainClass().set("org.pitest.mutationtest.commandline.MutationCoverageReport")
 
         ObjectFactory of = project.objects
+        rootDir = project.rootDir
 
         testPlugin = of.property(String)
         reportDir = of.directoryProperty()
@@ -305,19 +309,19 @@ class PitestTask extends JavaExec {
 
     @Input
     String getAdditionalClasspathFilePath() {
-        return additionalClasspathFile.asFile.get().relativePath(project.rootProject.rootDir)
+        return additionalClasspathFile.asFile.get().relativePath(rootDir)
     }
 
     @Input
     @Optional
     String getHistoryInputLocationPath() {
         //?. operator doesn't work with Gradle Providers
-        return historyInputLocation.isPresent() ? historyInputLocation.asFile.get().relativePath(project.rootProject.rootDir) : null
+        return historyInputLocation.isPresent() ? historyInputLocation.asFile.get().relativePath(rootDir) : null
     }
 
     @Input
     String getDefaultFileForHistoryDataPath() {
-        return defaultFileForHistoryData.asFile.get().relativePath(project.rootProject.rootDir)
+        return defaultFileForHistoryData.asFile.get().relativePath(rootDir)
     }
 
     @Input


### PR DESCRIPTION
The fix has a test but it's not hooked into the build because of cascading version incompatibility issues, which the pitest-gradle-plugin project needs to deal with.