### PR TITLE
[#333] Fix Gradle configuration cache issues for 8.1 and up

### DIFF
--- a/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/Junit5FunctionalSpec.groovy
+++ b/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/Junit5FunctionalSpec.groovy
@@ -2,6 +2,7 @@ package info.solidsoft.gradle.pitest.functional
 
 import groovy.transform.CompileDynamic
 import nebula.test.functional.ExecutionResult
+import spock.lang.Ignore
 import spock.lang.Issue
 
 @CompileDynamic
@@ -83,6 +84,20 @@ class Junit5FunctionalSpec extends AbstractPitestFunctionalSpec {
         and:
             result.standardOutput.contains('Configuration cache entry stored')
             result2.standardOutput.contains('Reusing configuration cache.')
+    }
+
+    @Issue("https://github.com/szpak/gradle-pitest-plugin/issues/333")
+    @Ignore("This requires Gradle 8.1, and its Groovy is too modern for Spock 2.3-groovy-2.5, and Gradle 6.9.2 is too old for 2.3-groovy-3.0.")
+    void "should not reference project data at execution time"() {
+        given:
+            gradleVersion = "8.1"
+            copyResources("testProjects/junit5simple", "")
+        when:
+            ExecutionResult result = runTasks('pitest', '--configuration-cache', '--rerun-tasks')
+        then:
+            !result.standardError.contains('invocation of \'Task.project\' at execution time is unsupported.')
+            !result.failure
+            result.wasExecuted('pitest')
     }
 
 }

--- a/src/main/groovy/info/solidsoft/gradle/pitest/PitestTask.groovy
+++ b/src/main/groovy/info/solidsoft/gradle/pitest/PitestTask.groovy
@@ -249,10 +249,14 @@ class PitestTask extends JavaExec {
     @Optional
     List<String> overriddenTargetTests  //should be Set<String> or SetProperty but it's not supported in Gradle as of 5.6.1
 
+    @Internal
+    File rootDir
+
     PitestTask() {
         getMainClass().set("org.pitest.mutationtest.commandline.MutationCoverageReport")
 
         ObjectFactory of = project.objects
+        rootDir = project.rootDir
 
         testPlugin = of.property(String)
         reportDir = of.directoryProperty()
@@ -305,19 +309,19 @@ class PitestTask extends JavaExec {
 
     @Input
     String getAdditionalClasspathFilePath() {
-        return additionalClasspathFile.asFile.get().relativePath(project.rootProject.rootDir)
+        return additionalClasspathFile.asFile.get().relativePath(rootDir)
     }
 
     @Input
     @Optional
     String getHistoryInputLocationPath() {
         //?. operator doesn't work with Gradle Providers
-        return historyInputLocation.isPresent() ? historyInputLocation.asFile.get().relativePath(project.rootProject.rootDir) : null
+        return historyInputLocation.isPresent() ? historyInputLocation.asFile.get().relativePath(rootDir) : null
     }
 
     @Input
     String getDefaultFileForHistoryDataPath() {
-        return defaultFileForHistoryData.asFile.get().relativePath(project.rootProject.rootDir)
+        return defaultFileForHistoryData.asFile.get().relativePath(rootDir)
     }
 
     @Input


### PR DESCRIPTION
The fix has a test but it's not hooked into the build because of cascading version incompatibility issues, which the pitest-gradle-plugin project needs to deal with.