### PR TITLE
Automatically add junit-platform-launcher for JUnit Platform projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
  - Automatically add `junit-platform-launcher` dependency to `testRuntimeOnly` for JUnit Platform projects - [#337](https://github.com/szpak/gradle-pitest-plugin/issues/337) - help from [Björn Kautler](https://github.com/Vampire)
  - Remove deprecated `Project.getConvention()` usage (in Gradle 8.2+) - [#343](https://github.com/szpak/gradle-pitest-plugin/issues/343)
+ - PIT 1.14.4 by default
  - Basic regression testing with Gradle up to 8.2
 
 **Compatibility notes**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,17 @@
 
 ## 1.14.0 - Unreleased
 
- - Remove deprecated Project.getConvention() usage (in Gradle 8.2+) - [#343](https://github.com/szpak/gradle-pitest-plugin/issues/343)
+ - Automatically add `junit-platform-launcher` dependency to `testRuntimeOnly` for JUnit Platform projects - [#337](https://github.com/szpak/gradle-pitest-plugin/issues/337) - help from [Björn Kautler](https://github.com/Vampire)
+ - Remove deprecated `Project.getConvention()` usage (in Gradle 8.2+) - [#343](https://github.com/szpak/gradle-pitest-plugin/issues/343)
  - Basic regression testing with Gradle up to 8.2
+
+**Compatibility notes**
+Starting with PIT 1.14.0 (with pitest-junit-plugin 1.2.0+) `junit-platform-launcher` is no longer shaded and has to be explicitly added to avoid:
+"Minion exited abnormally due to UNKNOWN_ERROR" or "NoClassDefFoundError: org.junit.platform.launcher.core.LauncherFactory".
+
+As an experimental (incubating) feature, `junit-platform-launcher` is automatically added to the `testRuntimeOnly` configuration for the JUnit Platform projects.
+
+**PLEASE NOTE**. This feature is experimental and might not work as expected in some corner cases. In that situation, just disable it with `addJUnitPlatformLauncher = false` and add the required dependency 'junit-platform-launcher' in a proper version to 'testRuntimeOnly' manually. More information: https://github.com/szpak/gradle-pitest-plugin/issues/337
 
 
 ## 1.9.11 - 2022-11-27

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
 
 sourceCompatibility = 1.8
 
-ext.pitestAggregatorVersion = "1.9.11"   //Must be equal to default PIT version in PitestPlugin
+ext.pitestAggregatorVersion = "1.14.4"   //Must be equal to default PIT version in PitestPlugin
 
 repositories {
     mavenCentral()

--- a/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/Junit5FunctionalSpec.groovy
+++ b/src/funcTest/groovy/info/solidsoft/gradle/pitest/functional/Junit5FunctionalSpec.groovy
@@ -33,7 +33,8 @@ class Junit5FunctionalSpec extends AbstractPitestFunctionalSpec {
             result.standardOutput.contains('Generated 2 mutations Killed 2 (100%)')
     }
 
-    @Issue(["https://github.com/szpak/gradle-pitest-plugin/issues/177", "https://github.com/szpak/gradle-pitest-plugin/issues/300"])
+    @Issue(["https://github.com/szpak/gradle-pitest-plugin/issues/177", "https://github.com/szpak/gradle-pitest-plugin/issues/300",
+        "https://github.com/szpak/gradle-pitest-plugin/issues/337"])
     void "should work with junit5 without explicitly adding dependency (#description)"() {
         given:
             copyResources("testProjects/junit5simple", "")
@@ -51,7 +52,8 @@ class Junit5FunctionalSpec extends AbstractPitestFunctionalSpec {
             result.standardOutput.contains("junit-platform-commons-${expectedJUnitPlatformVersion}.jar")
         where:
             buildFileName                             || expectedJunitPluginVersion | expectedJUnitJupiterVersion | expectedJUnitPlatformVersion
-            'build.gradle'                            || "1.0.0"                    | "5.8.0"                     | "1.8.0"
+            'build.gradle'                            || "1.2.0"                    | "5.10.0"                    | "1.10.0"
+            'build-pit-plugin-1.0.0-junit-5.8.gradle' || "1.0.0"                    | "5.8.0"                     | "1.8.0"
             'build-pit-1.8-junit-platform-5.7.gradle' || "0.14"                     | "5.7.0"                     | "1.7.0"
 
             description = "plugin $expectedJunitPluginVersion, junit $expectedJUnitJupiterVersion, platform $expectedJUnitPlatformVersion"

--- a/src/funcTest/resources/testProjects/junit5kotlin/build.gradle
+++ b/src/funcTest/resources/testProjects/junit5kotlin/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.kotlin_version = '1.3.61'
-    ext.junit5Version = '5.7.0'
-    ext.junitPlatformVersion = '1.7.0'
+    ext.junit5Version = '5.10.0'
+    ext.junitPlatformVersion = '1.10.0'
 
     repositories {
         mavenCentral()
@@ -31,7 +31,7 @@ dependencies {
     testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junit5Version"
     testImplementation "org.junit.platform:junit-platform-runner:$junitPlatformVersion"
 
-    pitest 'org.pitest:pitest-junit5-plugin:1.0.0'
+    pitest 'org.pitest:pitest-junit5-plugin:1.2.0'
 }
 
 compileKotlin {

--- a/src/funcTest/resources/testProjects/junit5simple/build-pit-plugin-1.0.0-junit-5.8.gradle
+++ b/src/funcTest/resources/testProjects/junit5simple/build-pit-plugin-1.0.0-junit-5.8.gradle
@@ -21,7 +21,7 @@ repositories {
 group = "pitest.test"
 
 dependencies {
-    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.10.0'
+    testImplementation 'org.junit.jupiter:junit-jupiter-engine:5.8.0'
 }
 
 test {
@@ -29,7 +29,5 @@ test {
 }
 
 pitest {
-    pitestVersion = "1.14.4"
-    junit5PluginVersion = "1.2.0"    //with no longer shaded junit-platform-launcher
-    verbose = true  //for "ClassNotFoundException: org.junit.platform.launcher.core.LauncherFactory" which should not happen
+    junit5PluginVersion = "1.0.0"
 }

--- a/src/main/groovy/info/solidsoft/gradle/pitest/AggregateReportTask.groovy
+++ b/src/main/groovy/info/solidsoft/gradle/pitest/AggregateReportTask.groovy
@@ -104,7 +104,7 @@ abstract class AggregateReportTask extends DefaultTask {
 
     @TaskAction
     void aggregate() {
-        logger.info("Aggregating pitest reports")
+        logger.info("Aggregating pitest reports (mutationFiles: {}, lineCoverageFiles: {})", mutationFiles.elements.getOrNull(), lineCoverageFiles.elements.getOrNull())
 
         WorkQueue workQueue = getWorkerExecutor().classLoaderIsolation { workerSpec ->
             workerSpec.getClasspath().from(getPitestReportClasspath())

--- a/src/main/groovy/info/solidsoft/gradle/pitest/PitestPlugin.groovy
+++ b/src/main/groovy/info/solidsoft/gradle/pitest/PitestPlugin.groovy
@@ -23,6 +23,9 @@ import org.gradle.api.GradleException
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.ModuleVersionIdentifier
+import org.gradle.api.artifacts.result.ResolutionResult
+import org.gradle.api.artifacts.result.ResolvedComponentResult
 import org.gradle.api.file.FileCollection
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
@@ -112,6 +115,7 @@ class PitestPlugin implements Plugin<Project> {
         extension.fileExtensionsToFilter.set(DEFAULT_FILE_EXTENSIONS_TO_FILTER_FROM_CLASSPATH)
         extension.useClasspathFile.set(false)
         extension.verbosity.set("NO_SPINNER")
+        extension.addJUnitPlatformLauncher.set(true)
     }
 
     private void failWithMeaningfulErrorMessageOnUnsupportedConfigurationInRootProjectBuildScript() {
@@ -238,6 +242,52 @@ class PitestPlugin implements Plugin<Project> {
                 log.info("Adding JUnit 5 plugin for PIT as dependency: ${junit5PluginDependencyAsString}")
                 dependencies.add(project.dependencies.create(junit5PluginDependencyAsString))
             }
+        }
+
+        addJUnitPlatformLauncherDependencyIfNeeded()
+    }
+
+    private void addJUnitPlatformLauncherDependencyIfNeeded() {
+        Configuration testImplementation = project.configurations.findByName("testImplementation")
+        testImplementation.withDependencies { directDependencies ->
+            if (!extension.addJUnitPlatformLauncher.isPresent() || !extension.addJUnitPlatformLauncher.get()) {
+                log.info("'addJUnitPlatformLauncher' feature explicitly disabled in configuration. " +
+                    "Add junit-platform-launcher manually or expect 'Minion exited abnormally due to UNKNOWN_ERROR' or 'NoClassDefFoundError'")
+                return
+            }
+
+            //Note: For simplicity, adding also for older pitest-junit5-plugin versions (<1.2.0), which is not needed
+
+            final String orgJUnitPlatformGroup = "org.junit.platform"
+
+            log.debug("Direct ${testImplementation.name} dependencies (${directDependencies.size()}): ${directDependencies}")
+
+            //copy() seems to copy also something that refers to original configuration and generates StackOverflow on getting components
+            Configuration tmpTestImplementation = project.configurations.maybeCreate("tmpTestImplementation")
+            directDependencies.each { directDependency ->
+                tmpTestImplementation.dependencies.add(directDependency)
+            }
+
+            ResolutionResult resolutionResult = tmpTestImplementation.incoming.resolutionResult
+            Set<ResolvedComponentResult> allResolvedComponents = resolutionResult.allComponents
+            log.debug("All resolved components ${testImplementation.name} (${allResolvedComponents.size()}): ${allResolvedComponents}")
+
+            ResolvedComponentResult foundJunitPlatformComponent = allResolvedComponents.find { ResolvedComponentResult componentResult ->
+                ModuleVersionIdentifier moduleVersion = componentResult.moduleVersion
+                return moduleVersion.group == orgJUnitPlatformGroup &&
+                    (moduleVersion.name == "junit-platform-engine" || moduleVersion.name == "junit-platform-commons")
+            }
+
+            if (!foundJunitPlatformComponent) {
+                log.info("No ${orgJUnitPlatformGroup} components founds in ${testImplementation.name}, junit-platform-launcher will not be added")
+                return
+            }
+
+            String junitPlatformLauncherDependencyAsString = "${orgJUnitPlatformGroup}:junit-platform-launcher:${foundJunitPlatformComponent.moduleVersion.version}"
+            log.info("${orgJUnitPlatformGroup} component (${foundJunitPlatformComponent}) found in ${testImplementation.name}, " +
+                "adding junit-platform-launcher (${junitPlatformLauncherDependencyAsString}) to testRuntimeOnly")
+            project.configurations.findByName("testRuntimeOnly").dependencies.add(
+                project.dependencies.create(junitPlatformLauncherDependencyAsString))
         }
     }
 

--- a/src/main/groovy/info/solidsoft/gradle/pitest/PitestPlugin.groovy
+++ b/src/main/groovy/info/solidsoft/gradle/pitest/PitestPlugin.groovy
@@ -54,7 +54,7 @@ class PitestPlugin implements Plugin<Project> {
     public final static String PITEST_REPORT_DIRECTORY_NAME = 'pitest'
     public final static String PITEST_CONFIGURATION_NAME = 'pitest'
 
-    public final static String DEFAULT_PITEST_VERSION = '1.9.11'
+    public final static String DEFAULT_PITEST_VERSION = '1.14.4'
     @Internal   //6.4 due to main -> mainClass change to avoid deprecation warning in Gradle 7.x - https://github.com/szpak/gradle-pitest-plugin/pull/289
     public static final GradleVersion MINIMAL_SUPPORTED_GRADLE_VERSION = GradleVersion.version("6.4") //public as used also in regression tests
 

--- a/src/main/groovy/info/solidsoft/gradle/pitest/PitestPluginExtension.groovy
+++ b/src/main/groovy/info/solidsoft/gradle/pitest/PitestPluginExtension.groovy
@@ -250,6 +250,23 @@ class PitestPluginExtension {
     @Incubating
     final ListProperty<String> fileExtensionsToFilter
 
+    /**
+     * Adds 'junit-platform-launcher' automatically to the 'testRuntimeOnly' configuration.
+     *
+     * Starting with PIT 1.14.0 (with pitest-junit-plugin 1.2.0+) that dependency is no longer shaded and has to be explicitly added to avoid:
+     * "Minion exited abnormally due to UNKNOWN_ERROR" or "NoClassDefFoundError: org.junit.platform.launcher.core.LauncherFactory".
+     * This feature is enabled by default if junit-platform is found on the testImplementation classes.
+     *
+     * PLEASE NOTE. This feature is experimental and might not work as expected in some corner cases. In that situation, just disable it and add
+     * required dependency 'junit-platform-launcher' in a proper version to 'testRuntimeOnly' manually.
+     *
+     * More information: https://github.com/szpak/gradle-pitest-plugin/issues/337
+     *
+     * @since 1.14.0
+     */
+    @Incubating
+    final Property<Boolean> addJUnitPlatformLauncher
+
     final ReportAggregatorProperties reportAggregatorProperties
 
     PitestPluginExtension(Project project) {
@@ -303,6 +320,7 @@ class PitestPluginExtension {
         outputCharset = of.property(Charset)
         features = nullListPropertyOf(p, String)
         fileExtensionsToFilter = nullListPropertyOf(p, String)
+        addJUnitPlatformLauncher = of.property(Boolean)
         reportAggregatorProperties = new ReportAggregatorProperties(of)
     }
 


### PR DESCRIPTION
Automatically add junit-platform-launcher to testRuntimeOnly for JUnit Platform projects to avoid "UNKNOWN_ERROR" or:
"NoClassDefFoundError: org.junit.platform.launcher.core.LauncherFactory" with PIT 1.14.0+ (with pitest-junit-plugin 1.2.0+).

That dependency is no longer shaded. More details in #337.

The implementation was more complicated than in the Maven plugin and help provided by @Vampire was very helpful!

I keep it as draft, maybe @Vampire (or someone else) has an idea how to simplify the implementation (or sees any important not supported corner cases)?

Also bumped PIT to 1.14 to ensure the aforementioned changes there are properly supported.

Closes #337.
