### PR TITLE
Define plugins in build.gradle instead of .properties files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,3 +124,16 @@ tasks.withType(CodeNarc) { codeNarcTask ->
         }
     })
 }
+
+gradlePlugin {
+    plugins {
+        pitestPlugin {
+            id = 'info.solidsoft.pitest'
+            implementationClass = 'info.solidsoft.gradle.pitest.PitestPlugin'
+        }
+        pitestAggregatorPlugin {
+            id = 'info.solidsoft.pitest.aggregator'
+            implementationClass = 'info.solidsoft.gradle.pitest.PitestAggregatorPlugin'
+        }
+    }
+}

--- a/src/main/resources/META-INF/gradle-plugins/info.solidsoft.pitest.aggregator.properties
+++ b/src/main/resources/META-INF/gradle-plugins/info.solidsoft.pitest.aggregator.properties
@@ -1,1 +1,0 @@
-implementation-class=info.solidsoft.gradle.pitest.PitestAggregatorPlugin

--- a/src/main/resources/META-INF/gradle-plugins/info.solidsoft.pitest.properties
+++ b/src/main/resources/META-INF/gradle-plugins/info.solidsoft.pitest.properties
@@ -1,1 +1,0 @@
-implementation-class=info.solidsoft.gradle.pitest.PitestPlugin


### PR DESCRIPTION
While debugging a [crash involving this plugin](https://github.com/ben-manes/gradle-versions-plugin/issues/930), I set up a Gradle composite build with my repro project and the source for the Gradle plugins it was using.  I noticed that the other plugins were running from source, but `gradle-pitest-plugin` plugin wasn't.  After some experimentation, I found that the other plugins were using a `gradlePlugin` block [1] in their build.gradle files to generate the plugin descriptors, but `gradle-pitest-plugin` wasn't.  Switching `gradle-pitest-plugin` to use the `gradlePlugin` block allowed it to get picked up and run from source.

I'm not sure if any new tests need to be written for this, but if they do, I can take a shot at it.

[1]: https://docs.gradle.org/6.9.2/userguide/custom_plugins.html#sec:custom_plugins_standalone_project